### PR TITLE
Configure Dependabot for Gradle with daily updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: daily
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "io.gitlab.arturbosch.detekt"


### PR DESCRIPTION
Updated Dependabot configuration to use Gradle and changed update schedule to daily.