### PR TITLE
Remove sanitizeKdoc — redundant with KotlinPoet 2.3.0

### DIFF
--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/NameUtils.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/NameUtils.kt
@@ -45,13 +45,6 @@ fun String.toEnumConstantName(): String {
 fun String.toInlinedName(): String = replace(".", "_")
 
 /**
- * Sanitizes a string for safe inclusion in KDoc.
- * Escapes comment terminators that would break generated Kotlin source.
- */
-fun String.sanitizeKdoc(): String = replace("*/", "&#42;/")
-    .replace("/*", "/&#42;")
-
-/**
  * Generates a PascalCase operation name from HTTP method and path.
  * Path parameters like {id} become "ById", {userId} becomes "ByUserId".
  * Handles hyphens, underscores, and dots in path segments.

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/client/ClientGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/client/ClientGenerator.kt
@@ -22,7 +22,6 @@ import com.avsystem.justworks.core.gen.client.BodyGenerator.buildFunctionBody
 import com.avsystem.justworks.core.gen.client.ParametersGenerator.buildBodyParams
 import com.avsystem.justworks.core.gen.client.ParametersGenerator.buildNullableParameter
 import com.avsystem.justworks.core.gen.invoke
-import com.avsystem.justworks.core.gen.sanitizeKdoc
 import com.avsystem.justworks.core.gen.shared.toAuthParam
 import com.avsystem.justworks.core.gen.toCamelCase
 import com.avsystem.justworks.core.gen.toPascalCase
@@ -253,15 +252,15 @@ internal object ClientGenerator {
         }
 
         val kdocParts = mutableListOf<String>()
-        endpoint.summary?.let { kdocParts.add(it.sanitizeKdoc()) }
+        endpoint.summary?.let { kdocParts.add(it) }
         endpoint.description?.let {
             if (kdocParts.isNotEmpty()) kdocParts.add("")
-            kdocParts.add(it.sanitizeKdoc())
+            kdocParts.add(it)
         }
         val paramDocs = endpoint.parameters.filter { it.description != null }
         if (paramDocs.isNotEmpty() && kdocParts.isNotEmpty()) kdocParts.add("")
         paramDocs.forEach { param ->
-            kdocParts.add("@param ${param.name.toCamelCase()} ${param.description?.sanitizeKdoc()}")
+            kdocParts.add("@param ${param.name.toCamelCase()} ${param.description}")
         }
         if (kdocParts.isNotEmpty()) {
             funBuilder.addKdoc("%L", kdocParts.joinToString("\n"))

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -32,7 +32,6 @@ import com.avsystem.justworks.core.gen.model.ModelGenerator.generateDataClass
 import com.avsystem.justworks.core.gen.resolveInlineTypes
 import com.avsystem.justworks.core.gen.resolveSerialName
 import com.avsystem.justworks.core.gen.resolveTypeRef
-import com.avsystem.justworks.core.gen.sanitizeKdoc
 import com.avsystem.justworks.core.gen.shared.SerializersModuleGenerator
 import com.avsystem.justworks.core.gen.toCamelCase
 import com.avsystem.justworks.core.gen.toEnumConstantName
@@ -206,7 +205,7 @@ internal object ModelGenerator {
         }
 
         if (schema.description != null) {
-            parentBuilder.addKdoc("%L", schema.description.sanitizeKdoc())
+            parentBuilder.addKdoc("%L", schema.description)
         }
 
         // Generate nested subtypes
@@ -308,7 +307,7 @@ internal object ModelGenerator {
                 .builder(kotlinName, type)
                 .initializer(kotlinName)
                 .addAnnotation(AnnotationSpec.builder(SERIAL_NAME).addMember("%S", prop.name).build())
-                .apply { prop.description?.let { addKdoc("%L", it.sanitizeKdoc()) } }
+                .apply { prop.description?.let { addKdoc("%L", it) } }
                 .build()
         }
 
@@ -316,7 +315,7 @@ internal object ModelGenerator {
         builder.addProperties(propertySpecs)
 
         if (schema.description != null) {
-            builder.addKdoc("%L", schema.description.sanitizeKdoc())
+            builder.addKdoc("%L", schema.description)
         }
     }
 
@@ -339,7 +338,7 @@ internal object ModelGenerator {
         )
 
         if (schema.description != null) {
-            typeSpec.addKdoc("%L", schema.description.sanitizeKdoc())
+            typeSpec.addKdoc("%L", schema.description)
         }
 
         return FileSpec.builder(className).addType(typeSpec.build()).build()
@@ -565,13 +564,13 @@ internal object ModelGenerator {
                         .builder(SERIAL_NAME)
                         .addMember("%S", value.name)
                         .build(),
-                ).apply { value.description?.let { addKdoc("%L", it.sanitizeKdoc()) } }
+                ).apply { value.description?.let { addKdoc("%L", it) } }
                 .build()
             typeSpec.addEnumConstant(enumRegistry.register(value.name.toEnumConstantName()), anonymousClass)
         }
 
         if (enum.description != null) {
-            typeSpec.addKdoc("%L", enum.description.sanitizeKdoc())
+            typeSpec.addKdoc("%L", enum.description)
         }
 
         return FileSpec
@@ -682,7 +681,7 @@ internal object ModelGenerator {
         val typeAlias = TypeAliasSpec.builder(schema.name, primitiveType)
 
         if (schema.description != null) {
-            typeAlias.addKdoc("%L", schema.description.sanitizeKdoc())
+            typeAlias.addKdoc("%L", schema.description)
         }
 
         return FileSpec


### PR DESCRIPTION
## Summary
- KotlinPoet 2.3.0 ([#2258](https://github.com/square/kotlinpoet/pull/2258)) escapes `/*` and `*/` in `CodeWriter.emitKdoc` (replaces with `&#42;`), identical to local `sanitizeKdoc()` helper.
- Removed `sanitizeKdoc()` extension from `NameUtils.kt` and all 9 call sites in `ClientGenerator.kt` / `ModelGenerator.kt`.
- No behavioral change in generated output.

## Test plan
- [x] `./gradlew ktlintCheck test` passes
- [ ] Verify generated KDoc still escapes comment terminators on a schema containing `*/` in description

🤖 Generated with [Claude Code](https://claude.com/claude-code)