### PR TITLE
feat: generate Kotlin Set for array schemas with uniqueItems

### DIFF
--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineSchemaKey.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineSchemaKey.kt
@@ -42,7 +42,7 @@ internal data class InlineSchemaKey(val properties: Set<PropertyKey>) {
                 contextHint = "",
             )
 
-            is TypeRef.Array -> TypeRef.Array(normalizeType(type.items))
+            is TypeRef.Array -> TypeRef.Array(normalizeType(type.items), type.unique)
 
             is TypeRef.Map -> TypeRef.Map(normalizeType(type.valueType))
 

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineTypeResolver.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineTypeResolver.kt
@@ -24,7 +24,7 @@ internal fun ApiSpec.resolveTypeRef(type: TypeRef, nameMap: Map<InlineSchemaKey,
     }
 
     is TypeRef.Array -> {
-        TypeRef.Array(resolveTypeRef(type.items, nameMap))
+        TypeRef.Array(resolveTypeRef(type.items, nameMap), type.unique)
     }
 
     is TypeRef.Map -> {

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/Utils.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/Utils.kt
@@ -14,6 +14,7 @@ import com.squareup.kotlinpoet.LIST
 import com.squareup.kotlinpoet.LONG
 import com.squareup.kotlinpoet.MAP
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.SET
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
 
@@ -47,7 +48,7 @@ internal fun TypeRef.toTypeName(): TypeName = when (this) {
     }
 
     is TypeRef.Array -> {
-        LIST.parameterizedBy(items.toTypeName())
+        (if (unique) SET else LIST).parameterizedBy(items.toTypeName())
     }
 
     is TypeRef.Map -> {

--- a/core/src/main/kotlin/com/avsystem/justworks/core/model/TypeRef.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/model/TypeRef.kt
@@ -3,7 +3,7 @@ package com.avsystem.justworks.core.model
 sealed interface TypeRef {
     data class Primitive(val type: PrimitiveType) : TypeRef
 
-    data class Array(val items: TypeRef) : TypeRef
+    data class Array(val items: TypeRef, val unique: Boolean = false) : TypeRef
 
     data class Reference(val schemaName: String) : TypeRef
 

--- a/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
@@ -467,7 +467,10 @@ object SpecParser {
 
         "boolean" -> TypeRef.Primitive(PrimitiveType.BOOLEAN)
 
-        "array" -> TypeRef.Array(items?.toTypeRef(contextName?.let { "${it}Item" }) ?: TypeRef.Unknown)
+        "array" -> TypeRef.Array(
+            items?.toTypeRef(contextName?.let { "${it}Item" }) ?: TypeRef.Unknown,
+            unique = uniqueItems == true,
+        )
 
         "object" -> when (val ap = additionalProperties) {
             is Schema<*> -> TypeRef.Map(ap.toTypeRef())

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/InlineSchemaDedupTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/InlineSchemaDedupTest.kt
@@ -146,6 +146,32 @@ class InlineSchemaDedupTest {
     }
 
     @Test
+    fun `array property differing only in uniqueItems produces different keys`() {
+        val listProps = listOf(
+            PropertyModel(
+                "tags",
+                TypeRef.Array(TypeRef.Primitive(PrimitiveType.STRING), unique = false),
+                null,
+                nullable = false,
+            ),
+        )
+        val setProps = listOf(
+            PropertyModel(
+                "tags",
+                TypeRef.Array(TypeRef.Primitive(PrimitiveType.STRING), unique = true),
+                null,
+                nullable = false,
+            ),
+        )
+        val required = setOf("tags")
+
+        val listKey = InlineSchemaKey.from(listProps, required)
+        val setKey = InlineSchemaKey.from(setProps, required)
+
+        assertNotEquals(listKey, setKey)
+    }
+
+    @Test
     fun `collision with existing inline schema name uses numeric suffix`() {
         val registry = NameRegistry()
 

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/TypeMappingTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/TypeMappingTest.kt
@@ -87,6 +87,20 @@ class TypeMappingTest {
         assertEquals("kotlin.collections.List<kotlin.String>", result.toString())
     }
 
+    @Test
+    fun `maps unique Array of String to Set of String`() {
+        val ref = TypeRef.Array(TypeRef.Primitive(PrimitiveType.STRING), unique = true)
+        val result = map(ref)
+        assertEquals("kotlin.collections.Set<kotlin.String>", result.toString())
+    }
+
+    @Test
+    fun `maps unique Array of Reference to Set of model class`() {
+        val ref = TypeRef.Array(TypeRef.Reference("Pet"), unique = true)
+        val result = map(ref)
+        assertEquals("kotlin.collections.Set<com.example.model.Pet>", result.toString())
+    }
+
     // -- Map --
 
     @Test

--- a/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserTest.kt
@@ -13,6 +13,7 @@ import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -632,7 +633,38 @@ class SpecParserTest : SpecParserTestBase() {
         val tagList = spec.schemas.find { it.name == "TagList" }
             ?: fail("TagList schema not found")
         val underlying = assertNotNull(tagList.underlyingType, "underlyingType should be set")
-        assertIs<TypeRef.Array>(underlying)
+        val array = assertIs<TypeRef.Array>(underlying)
+        assertFalse(array.unique, "array without uniqueItems should not be unique")
+    }
+
+    @Test
+    fun `array property with uniqueItems is parsed as unique Array`() {
+        val spec = parseSpec(
+            """
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                User:
+                  type: object
+                  properties:
+                    tags:
+                      type: array
+                      uniqueItems: true
+                      items:
+                        type: string
+            """.trimIndent().toTempFile(),
+        )
+
+        val user = spec.schemas.find { it.name == "User" }
+            ?: fail("User schema not found")
+        val tags = user.properties.find { it.name == "tags" }
+            ?: fail("tags property not found")
+        val array = assertIs<TypeRef.Array>(tags.type)
+        assertTrue(array.unique, "array with uniqueItems should be unique")
     }
 
     @Test


### PR DESCRIPTION
## Summary
OpenAPI array schemas with `uniqueItems: true` now generate Kotlin `Set` instead of `List`, enforcing uniqueness at the type level in generated client models.

Closes #73.

### Example
```yaml
tags:
  type: array
  uniqueItems: true
  items:
    type: string
```
→ generates `Set<String>` (was `List<String>`).

## Changes
- `TypeRef.Array` gains `unique: Boolean = false`
- `SpecParser` reads `uniqueItems` from the schema
- `toTypeName()` emits `SET` vs `LIST` based on `unique`
- `unique` preserved through inline-schema normalization/resolution

## Tests
- `TypeMappingTest`: unique Array of String/Reference → `Set<…>`
- `SpecParserTest`: `uniqueItems: true` parsed as `unique` Array; non-unique stays `false`

Full test suite + ktlint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)