### PR TITLE
Generate typed enums for inline enums in array items

### DIFF
--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineCollector.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineCollector.kt
@@ -1,0 +1,80 @@
+package com.avsystem.justworks.core.gen
+
+import com.avsystem.justworks.core.model.ApiSpec
+import com.avsystem.justworks.core.model.EnumModel
+import com.avsystem.justworks.core.model.SchemaModel
+import com.avsystem.justworks.core.model.TypeRef
+
+// Hoists anonymous TypeRef.InlineType nodes into named models, producing the
+// structural-key -> name maps consumed by resolveInlineTypes.
+
+private fun ApiSpec.topLevelTypeRefs(): List<TypeRef> {
+    val endpointRefs = endpoints.flatMap { endpoint ->
+        val requestRef = endpoint.requestBody?.schema
+        val responseRefs = endpoint.responses.values.map { it.schema }
+        responseRefs + requestRef
+    }
+    val schemaPropertyRefs = schemas.flatMap { schema -> schema.properties.map { it.type } }
+    return (endpointRefs + schemaPropertyRefs).filterNotNull()
+}
+
+private val descendants = DeepRecursiveFunction<TypeRef, List<TypeRef>> { type ->
+    listOf(type) + when (type) {
+        is TypeRef.Inline -> type.properties.flatMap { callRecursive(it.type) }
+        is TypeRef.Array -> callRecursive(type.items)
+        is TypeRef.Map -> callRecursive(type.valueType)
+        is TypeRef.Primitive, is TypeRef.Reference, is TypeRef.InlineEnum, TypeRef.Unknown -> emptyList()
+    }
+}
+
+private inline fun <reified T : TypeRef.InlineType> ApiSpec.inlineRefs(): List<T> =
+    topLevelTypeRefs().flatMap { descendants(it) }.filterIsInstance<T>()
+
+context(nameRegistry: NameRegistry)
+private fun <T : TypeRef.InlineType, K, M> Iterable<T>.toNamedModels(
+    keyOf: (T) -> K,
+    modelOf: (T, String) -> M,
+): Pair<List<M>, Map<K, String>> {
+    val nameMap = mutableMapOf<K, String>()
+    val models = asSequence()
+        .sortedBy { it.contextHint }
+        .distinctBy(keyOf)
+        .map { ref ->
+            val generatedName = nameRegistry.register(ref.contextHint.toInlinedName())
+            nameMap[keyOf(ref)] = generatedName
+            modelOf(ref, generatedName)
+        }.toList()
+    return models to nameMap
+}
+
+context(_: NameRegistry)
+internal fun ApiSpec.collectInlineSchemas(): Pair<List<SchemaModel>, Map<InlineSchemaKey, String>> =
+    inlineRefs<TypeRef.Inline>().toNamedModels(
+        keyOf = { InlineSchemaKey.from(it.properties, it.requiredProperties) },
+        modelOf = { ref, name ->
+            SchemaModel(
+                name = name,
+                description = null,
+                properties = ref.properties,
+                requiredProperties = ref.requiredProperties,
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        },
+    )
+
+context(_: NameRegistry)
+internal fun ApiSpec.collectInlineEnums(): Pair<List<EnumModel>, Map<InlineEnumKey, String>> =
+    inlineRefs<TypeRef.InlineEnum>().toNamedModels(
+        keyOf = InlineEnumKey::from,
+        modelOf = { ref, name ->
+            EnumModel(
+                name = name,
+                description = null,
+                type = ref.backingType,
+                values = ref.values.map { EnumModel.Value(it) },
+            )
+        },
+    )

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineCollector.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineCollector.kt
@@ -27,17 +27,16 @@ private val descendants = DeepRecursiveFunction<TypeRef, List<TypeRef>> { type -
     }
 }
 
-private inline fun <reified T : TypeRef.InlineType> ApiSpec.inlineRefs(): List<T> =
-    topLevelTypeRefs().flatMap { descendants(it) }.filterIsInstance<T>()
+private inline fun <reified T : TypeRef.InlineType> ApiSpec.inlineRefs(): Sequence<T> =
+    topLevelTypeRefs().asSequence().flatMap { descendants(it) }.filterIsInstance<T>()
 
 context(nameRegistry: NameRegistry)
-private fun <T : TypeRef.InlineType, K, M> Iterable<T>.toNamedModels(
+private fun <T : TypeRef.InlineType, K, M> Sequence<T>.toNamedModels(
     keyOf: (T) -> K,
     modelOf: (T, String) -> M,
 ): Pair<List<M>, Map<K, String>> {
     val nameMap = mutableMapOf<K, String>()
-    val models = asSequence()
-        .sortedBy { it.contextHint }
+    val models = sortedBy { it.contextHint }
         .distinctBy(keyOf)
         .map { ref ->
             val generatedName = nameRegistry.register(ref.contextHint.toInlinedName())
@@ -48,8 +47,8 @@ private fun <T : TypeRef.InlineType, K, M> Iterable<T>.toNamedModels(
 }
 
 context(_: NameRegistry)
-internal fun ApiSpec.collectInlineSchemas(): Pair<List<SchemaModel>, Map<InlineSchemaKey, String>> =
-    inlineRefs<TypeRef.Inline>().toNamedModels(
+internal fun collectInlineSchemas(spec: ApiSpec): Pair<List<SchemaModel>, Map<InlineSchemaKey, String>> =
+    spec.inlineRefs<TypeRef.Inline>().toNamedModels(
         keyOf = { InlineSchemaKey.from(it.properties, it.requiredProperties) },
         modelOf = { ref, name ->
             SchemaModel(
@@ -66,8 +65,8 @@ internal fun ApiSpec.collectInlineSchemas(): Pair<List<SchemaModel>, Map<InlineS
     )
 
 context(_: NameRegistry)
-internal fun ApiSpec.collectInlineEnums(): Pair<List<EnumModel>, Map<InlineEnumKey, String>> =
-    inlineRefs<TypeRef.InlineEnum>().toNamedModels(
+internal fun collectInlineEnums(spec: ApiSpec): Pair<List<EnumModel>, Map<InlineEnumKey, String>> =
+    spec.inlineRefs<TypeRef.InlineEnum>().toNamedModels(
         keyOf = InlineEnumKey::from,
         modelOf = { ref, name ->
             EnumModel(

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineCollector.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineCollector.kt
@@ -8,13 +8,11 @@ import com.avsystem.justworks.core.model.TypeRef
 // Hoists anonymous TypeRef.InlineType nodes into named models, producing the
 // structural-key -> name maps consumed by resolveInlineTypes.
 
-private fun ApiSpec.topLevelTypeRefs(): List<TypeRef> {
-    val endpointRefs = endpoints.flatMap { endpoint ->
-        val requestRef = endpoint.requestBody?.schema
-        val responseRefs = endpoint.responses.values.map { it.schema }
-        responseRefs + requestRef
+private fun ApiSpec.topLevelTypeRefs(): Sequence<TypeRef> {
+    val endpointRefs = endpoints.asSequence().flatMap { endpoint ->
+        endpoint.responses.values.map { it.schema } + endpoint.requestBody?.schema
     }
-    val schemaPropertyRefs = schemas.flatMap { schema -> schema.properties.map { it.type } }
+    val schemaPropertyRefs = schemas.asSequence().flatMap { schema -> schema.properties.map { it.type } }
     return (endpointRefs + schemaPropertyRefs).filterNotNull()
 }
 
@@ -28,7 +26,7 @@ private val descendants = DeepRecursiveFunction<TypeRef, List<TypeRef>> { type -
 }
 
 private inline fun <reified T : TypeRef.InlineType> ApiSpec.inlineRefs(): Sequence<T> =
-    topLevelTypeRefs().asSequence().flatMap { descendants(it) }.filterIsInstance<T>()
+    topLevelTypeRefs().flatMap { descendants(it) }.filterIsInstance<T>()
 
 context(nameRegistry: NameRegistry)
 private fun <T : TypeRef.InlineType, K, M> Sequence<T>.toNamedModels(

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineSchemaKey.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineSchemaKey.kt
@@ -46,6 +46,8 @@ internal data class InlineSchemaKey(val properties: Set<PropertyKey>) {
 
             is TypeRef.Map -> TypeRef.Map(normalizeType(type.valueType))
 
+            is TypeRef.InlineEnum -> type.copy(contextHint = "")
+
             else -> type
         }
     }

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineSchemaKey.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineSchemaKey.kt
@@ -24,7 +24,7 @@ internal data class InlineSchemaKey(val properties: Set<PropertyKey>) {
             val keys = properties.map {
                 PropertyKey(
                     name = it.name,
-                    type = normalizeType(it.type),
+                    type = it.type.normalized(),
                     required = it.name in required,
                     nullable = it.nullable,
                     defaultValue = it.defaultValue,
@@ -33,22 +33,22 @@ internal data class InlineSchemaKey(val properties: Set<PropertyKey>) {
             return InlineSchemaKey(keys.toSet())
         }
 
-        private fun normalizeType(type: TypeRef): TypeRef = when (type) {
+        private fun TypeRef.normalized(): TypeRef = when (this) {
             is TypeRef.Inline -> TypeRef.Inline(
-                properties = type.properties
-                    .map { it.copy(type = normalizeType(it.type)) }
+                properties = properties
+                    .map { it.copy(type = it.type.normalized()) }
                     .sortedBy { it.name },
-                requiredProperties = type.requiredProperties,
+                requiredProperties = this.requiredProperties,
                 contextHint = "",
             )
 
-            is TypeRef.Array -> TypeRef.Array(normalizeType(type.items), type.unique)
+            is TypeRef.Array -> TypeRef.Array(items.normalized(), unique)
 
-            is TypeRef.Map -> TypeRef.Map(normalizeType(type.valueType))
+            is TypeRef.Map -> TypeRef.Map(valueType.normalized())
 
-            is TypeRef.InlineEnum -> type.copy(contextHint = "")
+            is TypeRef.InlineEnum -> copy(contextHint = "")
 
-            else -> type
+            else -> this
         }
     }
 }

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineTypeResolver.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineTypeResolver.kt
@@ -2,6 +2,7 @@ package com.avsystem.justworks.core.gen
 
 import com.avsystem.justworks.core.model.ApiSpec
 import com.avsystem.justworks.core.model.Endpoint
+import com.avsystem.justworks.core.model.EnumBackingType
 import com.avsystem.justworks.core.model.PropertyModel
 import com.avsystem.justworks.core.model.RequestBody
 import com.avsystem.justworks.core.model.Response
@@ -9,10 +10,26 @@ import com.avsystem.justworks.core.model.SchemaModel
 import com.avsystem.justworks.core.model.TypeRef
 
 /**
- * Resolves a single [TypeRef.Inline] to [TypeRef.Reference] using the provided [nameMap].
- * Non-inline types are returned as-is; containers ([TypeRef.Array], [TypeRef.Map]) are resolved recursively.
+ * Structural key for an inline enum, ignoring [TypeRef.InlineEnum.contextHint].
+ * Two inline enums are considered the same generated type if they share the same
+ * ordered values and backing type.
  */
-internal fun ApiSpec.resolveTypeRef(type: TypeRef, nameMap: Map<InlineSchemaKey, String>): TypeRef = when (type) {
+internal data class InlineEnumKey(val values: List<String>, val backingType: EnumBackingType) {
+    companion object {
+        fun from(type: TypeRef.InlineEnum) = InlineEnumKey(type.values, type.backingType)
+    }
+}
+
+/**
+ * Resolves a single [TypeRef.Inline]/[TypeRef.InlineEnum] to [TypeRef.Reference] using the
+ * provided maps. Non-inline types are returned as-is; containers ([TypeRef.Array], [TypeRef.Map])
+ * are resolved recursively.
+ */
+internal fun ApiSpec.resolveTypeRef(
+    type: TypeRef,
+    nameMap: Map<InlineSchemaKey, String>,
+    enumNameMap: Map<InlineEnumKey, String> = emptyMap(),
+): TypeRef = when (type) {
     is TypeRef.Inline -> {
         val key = InlineSchemaKey.from(type.properties, type.requiredProperties)
         val className = nameMap[key]
@@ -23,12 +40,21 @@ internal fun ApiSpec.resolveTypeRef(type: TypeRef, nameMap: Map<InlineSchemaKey,
         TypeRef.Reference(className)
     }
 
+    is TypeRef.InlineEnum -> {
+        val className = enumNameMap[InlineEnumKey.from(type)]
+            ?: error(
+                "Missing inline enum mapping for key (contextHint=${type.contextHint}). " +
+                    "This indicates a mismatch between inline enum collection and resolution.",
+            )
+        TypeRef.Reference(className)
+    }
+
     is TypeRef.Array -> {
-        TypeRef.Array(resolveTypeRef(type.items, nameMap))
+        TypeRef.Array(resolveTypeRef(type.items, nameMap, enumNameMap))
     }
 
     is TypeRef.Map -> {
-        TypeRef.Map(resolveTypeRef(type.valueType, nameMap))
+        TypeRef.Map(resolveTypeRef(type.valueType, nameMap, enumNameMap))
     }
 
     else -> {
@@ -37,16 +63,19 @@ internal fun ApiSpec.resolveTypeRef(type: TypeRef, nameMap: Map<InlineSchemaKey,
 }
 
 /**
- * Rewrites all [TypeRef.Inline] references in an [ApiSpec] to [TypeRef.Reference],
- * using the provided [nameMap] that maps structural keys to generated class names.
+ * Rewrites all [TypeRef.Inline]/[TypeRef.InlineEnum] references in an [ApiSpec] to
+ * [TypeRef.Reference], using the provided maps from structural keys to generated names.
  *
- * This is applied once after inline schema collection, so downstream generators
- * never encounter [TypeRef.Inline] and need no special handling.
+ * This is applied once after inline collection, so downstream generators
+ * never encounter inline types and need no special handling.
  */
-internal fun ApiSpec.resolveInlineTypes(nameMap: Map<InlineSchemaKey, String>): ApiSpec {
-    if (nameMap.isEmpty()) return this
+internal fun ApiSpec.resolveInlineTypes(
+    nameMap: Map<InlineSchemaKey, String>,
+    enumNameMap: Map<InlineEnumKey, String> = emptyMap(),
+): ApiSpec {
+    if (nameMap.isEmpty() && enumNameMap.isEmpty()) return this
 
-    fun TypeRef.resolve(): TypeRef = resolveTypeRef(this, nameMap)
+    fun TypeRef.resolve(): TypeRef = resolveTypeRef(this, nameMap, enumNameMap)
 
     fun PropertyModel.resolve() = copy(type = type.resolve())
 

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/Utils.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/Utils.kt
@@ -20,13 +20,19 @@ import com.squareup.kotlinpoet.TypeName
 internal val TypeRef.properties: List<PropertyModel>
     get() = when (this) {
         is TypeRef.Inline -> properties
-        is TypeRef.Array, is TypeRef.Map, is TypeRef.Primitive, is TypeRef.Reference, TypeRef.Unknown -> emptyList()
+
+        is TypeRef.Array, is TypeRef.Map, is TypeRef.Primitive, is TypeRef.Reference, is TypeRef.InlineEnum,
+        TypeRef.Unknown,
+        -> emptyList()
     }
 
 internal val TypeRef.requiredProperties: Set<String>
     get() = when (this) {
         is TypeRef.Inline -> requiredProperties
-        is TypeRef.Array, is TypeRef.Map, is TypeRef.Primitive, is TypeRef.Reference, TypeRef.Unknown -> emptySet()
+
+        is TypeRef.Array, is TypeRef.Map, is TypeRef.Primitive, is TypeRef.Reference, is TypeRef.InlineEnum,
+        TypeRef.Unknown,
+        -> emptySet()
     }
 
 context(hierarchy: Hierarchy)
@@ -60,6 +66,10 @@ internal fun TypeRef.toTypeName(): TypeName = when (this) {
 
     is TypeRef.Inline -> {
         error("TypeRef.Inline should have been resolved by InlineTypeResolver (contextHint=$contextHint)")
+    }
+
+    is TypeRef.InlineEnum -> {
+        error("TypeRef.InlineEnum should have been resolved by InlineTypeResolver (contextHint=$contextHint)")
     }
 
     is TypeRef.Unknown -> {

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -7,8 +7,6 @@ import com.avsystem.justworks.core.gen.EXPERIMENTAL_SERIALIZATION_API
 import com.avsystem.justworks.core.gen.EXPERIMENTAL_UUID_API
 import com.avsystem.justworks.core.gen.Hierarchy
 import com.avsystem.justworks.core.gen.INSTANT
-import com.avsystem.justworks.core.gen.InlineEnumKey
-import com.avsystem.justworks.core.gen.InlineSchemaKey
 import com.avsystem.justworks.core.gen.JSON_CLASS_DISCRIMINATOR
 import com.avsystem.justworks.core.gen.JSON_CONTENT_POLYMORPHIC_SERIALIZER
 import com.avsystem.justworks.core.gen.JSON_ELEMENT
@@ -38,7 +36,6 @@ import com.avsystem.justworks.core.gen.resolveTypeRef
 import com.avsystem.justworks.core.gen.shared.SerializersModuleGenerator
 import com.avsystem.justworks.core.gen.toCamelCase
 import com.avsystem.justworks.core.gen.toEnumConstantName
-import com.avsystem.justworks.core.gen.toInlinedName
 import com.avsystem.justworks.core.gen.toPascalCase
 import com.avsystem.justworks.core.gen.toTypeName
 import com.avsystem.justworks.core.model.ApiSpec
@@ -79,8 +76,8 @@ internal object ModelGenerator {
     context(hierarchy: Hierarchy, nameRegistry: NameRegistry)
     fun generateWithResolvedSpec(spec: ApiSpec): GenerateResult {
         ensureReserved(spec, nameRegistry)
-        val (inlineSchemas, nameMap) = spec.collectInlineSchemas()
-        val (inlineEnums, enumNameMap) = spec.collectInlineEnums()
+        val (inlineSchemas, nameMap) = collectInlineSchemas(spec)
+        val (inlineEnums, enumNameMap) = collectInlineEnums(spec)
         val resolvedSpec = spec.resolveInlineTypes(nameMap, enumNameMap)
 
         val resolvedInlineSchemas = inlineSchemas.map { schema ->

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -630,37 +630,21 @@ internal object ModelGenerator {
     }
 
     /**
-     * Iteratively walks a [TypeRef] tree, yielding every reachable node.
-     * Descends through arrays, maps, and inline object properties; a visited guard on
-     * [TypeRef.Inline] prevents infinite recursion on self-referential schemas.
+     * Walks a [TypeRef] tree, yielding every reachable node (self included),
+     * descending through arrays, maps, and inline object properties.
      * Callers filter for the variant they need; structural deduplication happens downstream.
+     * Uses [DeepRecursiveFunction] for stack safety on deeply nested schemas.
      */
-    private fun walkTypeRefs(roots: List<TypeRef>): List<TypeRef> {
-        val todo = ArrayDeque(roots)
-        val visitedInline = mutableSetOf<TypeRef.Inline>()
-        val result = mutableListOf<TypeRef>()
-
-        while (todo.isNotEmpty()) {
-            val current = todo.removeFirst()
-            result += current
-            when (current) {
-                is TypeRef.Inline -> {
-                    if (visitedInline.add(current)) todo += current.properties.map { it.type }
-                }
-
-                is TypeRef.Array -> {
-                    todo += current.items
-                }
-
-                is TypeRef.Map -> {
-                    todo += current.valueType
-                }
-
-                else -> {}
-            }
+    private val descendants = DeepRecursiveFunction<TypeRef, List<TypeRef>> { type ->
+        listOf(type) + when (type) {
+            is TypeRef.Inline -> type.properties.flatMap { callRecursive(it.type) }
+            is TypeRef.Array -> callRecursive(type.items)
+            is TypeRef.Map -> callRecursive(type.valueType)
+            is TypeRef.Primitive, is TypeRef.Reference, is TypeRef.InlineEnum, TypeRef.Unknown -> emptyList()
         }
-        return result
     }
+
+    private fun walkTypeRefs(roots: List<TypeRef>): List<TypeRef> = roots.flatMap { descendants(it) }
 
     private val SchemaModel.isPrimitiveOnly: Boolean
         get() = properties.isEmpty() && allOf == null && oneOf == null && anyOf == null

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -27,6 +27,8 @@ import com.avsystem.justworks.core.gen.SERIAL_NAME
 import com.avsystem.justworks.core.gen.USE_SERIALIZERS
 import com.avsystem.justworks.core.gen.UUID_SERIALIZER
 import com.avsystem.justworks.core.gen.UUID_TYPE
+import com.avsystem.justworks.core.gen.collectInlineEnums
+import com.avsystem.justworks.core.gen.collectInlineSchemas
 import com.avsystem.justworks.core.gen.invoke
 import com.avsystem.justworks.core.gen.model.ModelGenerator.buildNestedVariant
 import com.avsystem.justworks.core.gen.model.ModelGenerator.generateDataClass
@@ -77,8 +79,8 @@ internal object ModelGenerator {
     context(hierarchy: Hierarchy, nameRegistry: NameRegistry)
     fun generateWithResolvedSpec(spec: ApiSpec): GenerateResult {
         ensureReserved(spec, nameRegistry)
-        val (inlineSchemas, nameMap) = collectAllInlineSchemas(spec)
-        val (inlineEnums, enumNameMap) = collectAllInlineEnums(spec)
+        val (inlineSchemas, nameMap) = spec.collectInlineSchemas()
+        val (inlineEnums, enumNameMap) = spec.collectInlineEnums()
         val resolvedSpec = spec.resolveInlineTypes(nameMap, enumNameMap)
 
         val resolvedInlineSchemas = inlineSchemas.map { schema ->
@@ -128,86 +130,6 @@ internal object ModelGenerator {
         nameRegistry.reserve(UUID_SERIALIZER.simpleName)
         nameRegistry.reserve(SERIALIZERS_MODULE.simpleName)
     }
-
-    /**
-     * Gathers all top-level [TypeRef]s from a spec's endpoints (request/response bodies)
-     * and component schema properties. Used as the traversal roots for inline collection.
-     */
-    private fun topLevelTypeRefs(spec: ApiSpec): List<TypeRef> {
-        val endpointRefs = spec.endpoints.flatMap { endpoint ->
-            val requestRef = endpoint.requestBody?.schema
-            val responseRefs = endpoint.responses.values.map { it.schema }
-            responseRefs + requestRef
-        }
-        val schemaPropertyRefs = spec.schemas.flatMap { schema -> schema.properties.map { it.type } }
-        return (endpointRefs + schemaPropertyRefs).filterNotNull()
-    }
-
-    /**
-     * Shared collect → deduplicate → name → model pipeline for inline definitions.
-     * [collect] traverses the type roots, [keyOf] gives the structural dedup key,
-     * and [modelOf] builds the output model.
-     */
-    context(nameRegistry: NameRegistry)
-    private fun <T : TypeRef.InlineType, K, M> collectInlineDefinitions(
-        spec: ApiSpec,
-        collect: (List<TypeRef>) -> List<T>,
-        keyOf: (T) -> K,
-        modelOf: (T, String) -> M,
-    ): Pair<List<M>, Map<K, String>> {
-        val nameMap = mutableMapOf<K, String>()
-        val models = collect(topLevelTypeRefs(spec))
-            .asSequence()
-            .sortedBy { it.contextHint }
-            .distinctBy(keyOf)
-            .map { ref ->
-                val generatedName = nameRegistry.register(ref.contextHint.toInlinedName())
-                nameMap[keyOf(ref)] = generatedName
-                modelOf(ref, generatedName)
-            }.toList()
-        return models to nameMap
-    }
-
-    context(_: NameRegistry)
-    private fun collectAllInlineSchemas(spec: ApiSpec): Pair<List<SchemaModel>, Map<InlineSchemaKey, String>> =
-        collectInlineDefinitions(
-            spec = spec,
-            collect = { walkTypeRefs(it).filterIsInstance<TypeRef.Inline>() },
-            keyOf = { InlineSchemaKey.from(it.properties, it.requiredProperties) },
-            modelOf = { ref, name ->
-                SchemaModel(
-                    name = name,
-                    description = null,
-                    properties = ref.properties,
-                    requiredProperties = ref.requiredProperties,
-                    allOf = null,
-                    oneOf = null,
-                    anyOf = null,
-                    discriminator = null,
-                )
-            },
-        )
-
-    /**
-     * Collects all inline enums (enums declared in array items or inline on a property,
-     * i.e. not as named component schemas), deduplicates them structurally, registers a
-     * generated name for each, and builds the corresponding [EnumModel]s.
-     */
-    context(_: NameRegistry)
-    private fun collectAllInlineEnums(spec: ApiSpec): Pair<List<EnumModel>, Map<InlineEnumKey, String>> =
-        collectInlineDefinitions(
-            spec = spec,
-            collect = { walkTypeRefs(it).filterIsInstance<TypeRef.InlineEnum>() },
-            keyOf = InlineEnumKey::from,
-            modelOf = { ref, name ->
-                EnumModel(
-                    name = name,
-                    description = null,
-                    type = ref.backingType,
-                    values = ref.values.map { EnumModel.Value(it) },
-                )
-            },
-        )
 
     context(hierarchy: Hierarchy)
     private fun generateSchemaFiles(schema: SchemaModel): List<FileSpec> = when {
@@ -625,23 +547,6 @@ internal object ModelGenerator {
             .addType(typeSpec.build())
             .build()
     }
-
-    /**
-     * Walks a [TypeRef] tree, yielding every reachable node (self included),
-     * descending through arrays, maps, and inline object properties.
-     * Callers filter for the variant they need; structural deduplication happens downstream.
-     * Uses [DeepRecursiveFunction] for stack safety on deeply nested schemas.
-     */
-    private val descendants = DeepRecursiveFunction<TypeRef, List<TypeRef>> { type ->
-        listOf(type) + when (type) {
-            is TypeRef.Inline -> type.properties.flatMap { callRecursive(it.type) }
-            is TypeRef.Array -> callRecursive(type.items)
-            is TypeRef.Map -> callRecursive(type.valueType)
-            is TypeRef.Primitive, is TypeRef.Reference, is TypeRef.InlineEnum, TypeRef.Unknown -> emptyList()
-        }
-    }
-
-    private fun walkTypeRefs(roots: List<TypeRef>): List<TypeRef> = roots.flatMap { descendants(it) }
 
     private val SchemaModel.isPrimitiveOnly: Boolean
         get() = properties.isEmpty() && allOf == null && oneOf == null && anyOf == null

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -662,25 +662,25 @@ internal object ModelGenerator {
      */
     private fun collectInlineEnumRefs(initialTodo: List<TypeRef?>): List<TypeRef.InlineEnum> {
         val todo = ArrayDeque(initialTodo.filterNotNull())
-        val visitedInline = linkedSetOf<TypeRef.Inline>()
-        val enums = linkedSetOf<TypeRef.InlineEnum>()
+        val visitedInline = mutableSetOf<TypeRef.Inline>()
+        val enums = mutableSetOf<TypeRef.InlineEnum>()
 
         while (todo.isNotEmpty()) {
             when (val current = todo.removeFirst()) {
                 is TypeRef.InlineEnum -> {
-                    enums.add(current)
+                    enums += current
                 }
 
                 is TypeRef.Inline if visitedInline.add(current) -> {
-                    todo.addAll(current.properties.map { it.type })
+                    todo += current.properties.map { it.type }
                 }
 
                 is TypeRef.Array -> {
-                    todo.add(current.items)
+                    todo += current.items
                 }
 
                 is TypeRef.Map -> {
-                    todo.add(current.valueType)
+                    todo += current.valueType
                 }
 
                 else -> {}

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -146,23 +146,22 @@ internal object ModelGenerator {
     /**
      * Shared collect → deduplicate → name → model pipeline for inline definitions.
      * [collect] traverses the type roots, [keyOf] gives the structural dedup key,
-     * [contextHintOf] supplies the name seed, and [modelOf] builds the output model.
+     * and [modelOf] builds the output model.
      */
     context(nameRegistry: NameRegistry)
-    private fun <T, K, M> collectInlineDefinitions(
+    private fun <T : TypeRef.InlineType, K, M> collectInlineDefinitions(
         spec: ApiSpec,
         collect: (List<TypeRef>) -> List<T>,
         keyOf: (T) -> K,
-        contextHintOf: (T) -> String,
         modelOf: (T, String) -> M,
     ): Pair<List<M>, Map<K, String>> {
         val nameMap = mutableMapOf<K, String>()
         val models = collect(topLevelTypeRefs(spec))
             .asSequence()
-            .sortedBy(contextHintOf)
+            .sortedBy { it.contextHint }
             .distinctBy(keyOf)
             .map { ref ->
-                val generatedName = nameRegistry.register(contextHintOf(ref).toInlinedName())
+                val generatedName = nameRegistry.register(ref.contextHint.toInlinedName())
                 nameMap[keyOf(ref)] = generatedName
                 modelOf(ref, generatedName)
             }.toList()
@@ -175,7 +174,6 @@ internal object ModelGenerator {
             spec = spec,
             collect = { walkTypeRefs(it).filterIsInstance<TypeRef.Inline>() },
             keyOf = { InlineSchemaKey.from(it.properties, it.requiredProperties) },
-            contextHintOf = { it.contextHint },
             modelOf = { ref, name ->
                 SchemaModel(
                     name = name,
@@ -201,7 +199,6 @@ internal object ModelGenerator {
             spec = spec,
             collect = { walkTypeRefs(it).filterIsInstance<TypeRef.InlineEnum>() },
             keyOf = InlineEnumKey::from,
-            contextHintOf = { it.contextHint },
             modelOf = { ref, name ->
                 EnumModel(
                     name = name,

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -676,11 +676,11 @@ internal object ModelGenerator {
                 }
 
                 is TypeRef.Array -> {
-                    todo.addFirst(current.items)
+                    todo.add(current.items)
                 }
 
                 is TypeRef.Map -> {
-                    todo.addFirst(current.valueType)
+                    todo.add(current.valueType)
                 }
 
                 else -> {}

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -7,6 +7,7 @@ import com.avsystem.justworks.core.gen.EXPERIMENTAL_SERIALIZATION_API
 import com.avsystem.justworks.core.gen.EXPERIMENTAL_UUID_API
 import com.avsystem.justworks.core.gen.Hierarchy
 import com.avsystem.justworks.core.gen.INSTANT
+import com.avsystem.justworks.core.gen.InlineEnumKey
 import com.avsystem.justworks.core.gen.InlineSchemaKey
 import com.avsystem.justworks.core.gen.JSON_CLASS_DISCRIMINATOR
 import com.avsystem.justworks.core.gen.JSON_CONTENT_POLYMORPHIC_SERIALIZER
@@ -77,12 +78,13 @@ internal object ModelGenerator {
     fun generateWithResolvedSpec(spec: ApiSpec): GenerateResult {
         ensureReserved(spec, nameRegistry)
         val (inlineSchemas, nameMap) = collectAllInlineSchemas(spec)
-        val resolvedSpec = spec.resolveInlineTypes(nameMap)
+        val (inlineEnums, enumNameMap) = collectAllInlineEnums(spec)
+        val resolvedSpec = spec.resolveInlineTypes(nameMap, enumNameMap)
 
         val resolvedInlineSchemas = inlineSchemas.map { schema ->
             schema.copy(
                 properties = schema.properties.map { prop ->
-                    prop.copy(type = resolvedSpec.resolveTypeRef(prop.type, nameMap))
+                    prop.copy(type = resolvedSpec.resolveTypeRef(prop.type, nameMap, enumNameMap))
                 },
             )
         }
@@ -103,7 +105,7 @@ internal object ModelGenerator {
 
         val inlineSchemaFiles = resolvedInlineSchemas.map { generateDataClass(it) }
 
-        val enumFiles = resolvedSpec.enums.map { generateEnumClass(it) }
+        val enumFiles = (resolvedSpec.enums + inlineEnums).map { generateEnumClass(it) }
 
         val serializersModuleFile = SerializersModuleGenerator.generate()
 
@@ -127,28 +129,56 @@ internal object ModelGenerator {
         nameRegistry.reserve(SERIALIZERS_MODULE.simpleName)
     }
 
-    context(nameRegistry: NameRegistry)
-    private fun collectAllInlineSchemas(spec: ApiSpec): Pair<List<SchemaModel>, Map<InlineSchemaKey, String>> {
+    /**
+     * Gathers all top-level [TypeRef]s from a spec's endpoints (request/response bodies)
+     * and component schema properties. Used as the traversal roots for inline collection.
+     */
+    private fun topLevelTypeRefs(spec: ApiSpec): List<TypeRef> {
         val endpointRefs = spec.endpoints.flatMap { endpoint ->
             val requestRef = endpoint.requestBody?.schema
             val responseRefs = endpoint.responses.values.map { it.schema }
             responseRefs + requestRef
         }
-
         val schemaPropertyRefs = spec.schemas.flatMap { schema -> schema.properties.map { it.type } }
+        return (endpointRefs + schemaPropertyRefs).filterNotNull()
+    }
 
-        val nameMap = mutableMapOf<InlineSchemaKey, String>()
-
-        val schemas = collectInlineTypeRefs(endpointRefs + schemaPropertyRefs)
+    /**
+     * Shared collect → deduplicate → name → model pipeline for inline definitions.
+     * [collect] traverses the type roots, [keyOf] gives the structural dedup key,
+     * [contextHintOf] supplies the name seed, and [modelOf] builds the output model.
+     */
+    context(nameRegistry: NameRegistry)
+    private fun <T, K, M> collectInlineDefinitions(
+        spec: ApiSpec,
+        collect: (List<TypeRef>) -> List<T>,
+        keyOf: (T) -> K,
+        contextHintOf: (T) -> String,
+        modelOf: (T, String) -> M,
+    ): Pair<List<M>, Map<K, String>> {
+        val nameMap = mutableMapOf<K, String>()
+        val models = collect(topLevelTypeRefs(spec))
             .asSequence()
-            .sortedBy { it.contextHint }
-            .distinctBy { InlineSchemaKey.from(it.properties, it.requiredProperties) }
+            .sortedBy(contextHintOf)
+            .distinctBy(keyOf)
             .map { ref ->
-                val key = InlineSchemaKey.from(ref.properties, ref.requiredProperties)
-                val generatedName = nameRegistry.register(ref.contextHint.toInlinedName())
-                nameMap[key] = generatedName
+                val generatedName = nameRegistry.register(contextHintOf(ref).toInlinedName())
+                nameMap[keyOf(ref)] = generatedName
+                modelOf(ref, generatedName)
+            }.toList()
+        return models to nameMap
+    }
+
+    context(_: NameRegistry)
+    private fun collectAllInlineSchemas(spec: ApiSpec): Pair<List<SchemaModel>, Map<InlineSchemaKey, String>> =
+        collectInlineDefinitions(
+            spec = spec,
+            collect = ::collectInlineTypeRefs,
+            keyOf = { InlineSchemaKey.from(it.properties, it.requiredProperties) },
+            contextHintOf = { it.contextHint },
+            modelOf = { ref, name ->
                 SchemaModel(
-                    name = generatedName,
+                    name = name,
                     description = null,
                     properties = ref.properties,
                     requiredProperties = ref.requiredProperties,
@@ -157,10 +187,30 @@ internal object ModelGenerator {
                     anyOf = null,
                     discriminator = null,
                 )
-            }.toList()
+            },
+        )
 
-        return schemas to nameMap
-    }
+    /**
+     * Collects all inline enums (enums declared in array items or inline on a property,
+     * i.e. not as named component schemas), deduplicates them structurally, registers a
+     * generated name for each, and builds the corresponding [EnumModel]s.
+     */
+    context(_: NameRegistry)
+    private fun collectAllInlineEnums(spec: ApiSpec): Pair<List<EnumModel>, Map<InlineEnumKey, String>> =
+        collectInlineDefinitions(
+            spec = spec,
+            collect = ::collectInlineEnumRefs,
+            keyOf = InlineEnumKey::from,
+            contextHintOf = { it.contextHint },
+            modelOf = { ref, name ->
+                EnumModel(
+                    name = name,
+                    description = null,
+                    type = ref.backingType,
+                    values = ref.values.map { EnumModel.Value(it) },
+                )
+            },
+        )
 
     context(hierarchy: Hierarchy)
     private fun generateSchemaFiles(schema: SchemaModel): List<FileSpec> = when {
@@ -606,6 +656,39 @@ internal object ModelGenerator {
         return visited.toList()
     }
 
+    /**
+     * Iteratively collects all [TypeRef.InlineEnum] instances from a [TypeRef] tree,
+     * descending through arrays, maps, and inline object properties.
+     */
+    private fun collectInlineEnumRefs(initialTodo: List<TypeRef?>): List<TypeRef.InlineEnum> {
+        val todo = ArrayDeque(initialTodo.filterNotNull())
+        val visitedInline = linkedSetOf<TypeRef.Inline>()
+        val enums = linkedSetOf<TypeRef.InlineEnum>()
+
+        while (todo.isNotEmpty()) {
+            when (val current = todo.removeFirst()) {
+                is TypeRef.InlineEnum -> {
+                    enums.add(current)
+                }
+
+                is TypeRef.Inline if visitedInline.add(current) -> {
+                    todo.addAll(current.properties.map { it.type })
+                }
+
+                is TypeRef.Array -> {
+                    todo.addFirst(current.items)
+                }
+
+                is TypeRef.Map -> {
+                    todo.addFirst(current.valueType)
+                }
+
+                else -> {}
+            }
+        }
+        return enums.toList()
+    }
+
     private val SchemaModel.isPrimitiveOnly: Boolean
         get() = properties.isEmpty() && allOf == null && oneOf == null && anyOf == null
 
@@ -614,7 +697,7 @@ internal object ModelGenerator {
         is TypeRef.Array -> items.containsUuid()
         is TypeRef.Map -> valueType.containsUuid()
         is TypeRef.Inline -> properties.any { it.type.containsUuid() }
-        is TypeRef.Reference, TypeRef.Unknown -> false
+        is TypeRef.Reference, is TypeRef.InlineEnum, TypeRef.Unknown -> false
     }
 
     private fun ApiSpec.usesUuid(): Boolean {

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -173,7 +173,7 @@ internal object ModelGenerator {
     private fun collectAllInlineSchemas(spec: ApiSpec): Pair<List<SchemaModel>, Map<InlineSchemaKey, String>> =
         collectInlineDefinitions(
             spec = spec,
-            collect = ::collectInlineTypeRefs,
+            collect = { walkTypeRefs(it).filterIsInstance<TypeRef.Inline>() },
             keyOf = { InlineSchemaKey.from(it.properties, it.requiredProperties) },
             contextHintOf = { it.contextHint },
             modelOf = { ref, name ->
@@ -199,7 +199,7 @@ internal object ModelGenerator {
     private fun collectAllInlineEnums(spec: ApiSpec): Pair<List<EnumModel>, Map<InlineEnumKey, String>> =
         collectInlineDefinitions(
             spec = spec,
-            collect = ::collectInlineEnumRefs,
+            collect = { walkTypeRefs(it).filterIsInstance<TypeRef.InlineEnum>() },
             keyOf = InlineEnumKey::from,
             contextHintOf = { it.contextHint },
             modelOf = { ref, name ->
@@ -630,49 +630,22 @@ internal object ModelGenerator {
     }
 
     /**
-     * Iteratively collects all [TypeRef.Inline] instances from a [TypeRef] tree.
+     * Iteratively walks a [TypeRef] tree, yielding every reachable node.
+     * Descends through arrays, maps, and inline object properties; a visited guard on
+     * [TypeRef.Inline] prevents infinite recursion on self-referential schemas.
+     * Callers filter for the variant they need; structural deduplication happens downstream.
      */
-    private fun collectInlineTypeRefs(initialTodo: List<TypeRef?>): List<TypeRef.Inline> {
-        val todo = ArrayDeque(initialTodo.filterNotNull())
-        val visited = linkedSetOf<TypeRef.Inline>()
-
-        while (todo.isNotEmpty()) {
-            when (val current = todo.removeFirst()) {
-                is TypeRef.Inline if visited.add(current) -> {
-                    todo.addAll(current.properties.map { it.type })
-                }
-
-                is TypeRef.Array -> {
-                    todo.addFirst(current.items)
-                }
-
-                is TypeRef.Map -> {
-                    todo.addFirst(current.valueType)
-                }
-
-                else -> {}
-            }
-        }
-        return visited.toList()
-    }
-
-    /**
-     * Iteratively collects all [TypeRef.InlineEnum] instances from a [TypeRef] tree,
-     * descending through arrays, maps, and inline object properties.
-     */
-    private fun collectInlineEnumRefs(initialTodo: List<TypeRef?>): List<TypeRef.InlineEnum> {
-        val todo = ArrayDeque(initialTodo.filterNotNull())
+    private fun walkTypeRefs(roots: List<TypeRef>): List<TypeRef> {
+        val todo = ArrayDeque(roots)
         val visitedInline = mutableSetOf<TypeRef.Inline>()
-        val enums = mutableSetOf<TypeRef.InlineEnum>()
+        val result = mutableListOf<TypeRef>()
 
         while (todo.isNotEmpty()) {
-            when (val current = todo.removeFirst()) {
-                is TypeRef.InlineEnum -> {
-                    enums += current
-                }
-
-                is TypeRef.Inline if visitedInline.add(current) -> {
-                    todo += current.properties.map { it.type }
+            val current = todo.removeFirst()
+            result += current
+            when (current) {
+                is TypeRef.Inline -> {
+                    if (visitedInline.add(current)) todo += current.properties.map { it.type }
                 }
 
                 is TypeRef.Array -> {
@@ -686,7 +659,7 @@ internal object ModelGenerator {
                 else -> {}
             }
         }
-        return enums.toList()
+        return result
     }
 
     private val SchemaModel.isPrimitiveOnly: Boolean

--- a/core/src/main/kotlin/com/avsystem/justworks/core/model/TypeRef.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/model/TypeRef.kt
@@ -15,6 +15,12 @@ sealed interface TypeRef {
         val contextHint: String, // "request"|"response"|property name for context-aware naming
     ) : TypeRef
 
+    data class InlineEnum(
+        val values: List<String>,
+        val backingType: EnumBackingType,
+        val contextHint: String, // property/item name for context-aware naming
+    ) : TypeRef
+
     data object Unknown : TypeRef
 }
 

--- a/core/src/main/kotlin/com/avsystem/justworks/core/model/TypeRef.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/model/TypeRef.kt
@@ -12,16 +12,24 @@ sealed interface TypeRef {
     data class Inline(
         val properties: List<PropertyModel>,
         val requiredProperties: Set<String>,
-        val contextHint: String, // "request"|"response"|property name for context-aware naming
-    ) : TypeRef
+        override val contextHint: String, // "request"|"response"|property name for context-aware naming
+    ) : InlineType
 
     data class InlineEnum(
         val values: List<String>,
         val backingType: EnumBackingType,
-        val contextHint: String, // property/item name for context-aware naming
-    ) : TypeRef
+        override val contextHint: String, // property/item name for context-aware naming
+    ) : InlineType
 
     data object Unknown : TypeRef
+
+    /**
+     * A schema defined inline (anonymously) that must be hoisted into a named generated
+     * declaration. [contextHint] is the seed used to derive that name.
+     */
+    sealed interface InlineType : TypeRef {
+        val contextHint: String
+    }
 }
 
 enum class PrimitiveType { STRING, INT, LONG, DOUBLE, FLOAT, BOOLEAN, BYTE_ARRAY, DATE_TIME, DATE, UUID }

--- a/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
@@ -459,9 +459,13 @@ object SpecParser {
     /** Resolves a [TypeRef] based on the schema's structural type/format, ignoring component identity. */
     context(_: ComponentSchemaIdentity, _: ComponentSchemas)
     private fun Schema<*>.resolveByType(contextName: String? = null): TypeRef = when (type) {
-        "string" -> STRING_FORMAT_MAP[format] ?: TypeRef.Primitive(PrimitiveType.STRING)
+        "string" -> inlineEnum(contextName, EnumBackingType.STRING)
+            ?: STRING_FORMAT_MAP[format]
+            ?: TypeRef.Primitive(PrimitiveType.STRING)
 
-        "integer" -> INTEGER_FORMAT_MAP[format] ?: TypeRef.Primitive(PrimitiveType.INT)
+        "integer" -> inlineEnum(contextName, EnumBackingType.INTEGER)
+            ?: INTEGER_FORMAT_MAP[format]
+            ?: TypeRef.Primitive(PrimitiveType.INT)
 
         "number" -> NUMBER_FORMAT_MAP[format] ?: TypeRef.Primitive(PrimitiveType.DOUBLE)
 
@@ -497,6 +501,20 @@ object SpecParser {
             this !in componentSchemaIdentity && type == "object" && !properties.isNullOrEmpty()
 
     private val Schema<*>.isEnumSchema get(): Boolean = !enum.isNullOrEmpty()
+
+    /**
+     * Builds a [TypeRef.InlineEnum] for an enum schema that is not a named component
+     * (e.g. an enum declared directly in array `items` or inline on a property).
+     * Named component enums are resolved to [TypeRef.Reference] before reaching here.
+     */
+    private fun Schema<*>.inlineEnum(contextName: String?, backingType: EnumBackingType): TypeRef.InlineEnum? =
+        enum?.filterNotNull()?.takeIf { it.isNotEmpty() }?.let { values ->
+            TypeRef.InlineEnum(
+                values = values.map { it.toString() },
+                backingType = backingType,
+                contextHint = contextName ?: "InlineEnum",
+            )
+        }
 
     context(_: ComponentSchemaIdentity, _: ComponentSchemas)
     private fun Schema<*>.propertyModels(required: Set<String>, createContext: (String) -> String? = { null }) =
@@ -554,7 +572,7 @@ object SpecParser {
             is TypeRef.Array -> callRecursive(typeRef.items)
             is TypeRef.Map -> callRecursive(typeRef.valueType)
             is TypeRef.Inline -> typeRef.properties.any { callRecursive(it.type) }
-            is TypeRef.Primitive, is TypeRef.Reference -> false
+            is TypeRef.Primitive, is TypeRef.Reference, is TypeRef.InlineEnum -> false
         }
     }
 

--- a/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
@@ -474,7 +474,7 @@ object SpecParser {
         "array" -> TypeRef.Array(items?.toTypeRef(contextName?.let { "${it}Item" }) ?: TypeRef.Unknown)
 
         "object" -> when (val ap = additionalProperties) {
-            is Schema<*> -> TypeRef.Map(ap.toTypeRef())
+            is Schema<*> -> TypeRef.Map(ap.toTypeRef(contextName?.let { "${it}Value" }))
             is Boolean -> if (ap) TypeRef.Map(TypeRef.Unknown) else TypeRef.Unknown
             else -> title?.let(TypeRef::Reference) ?: TypeRef.Unknown
         }

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorInlineEnumTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorInlineEnumTest.kt
@@ -1,0 +1,83 @@
+package com.avsystem.justworks.core.gen
+
+import com.avsystem.justworks.core.gen.model.ModelGenerator
+import com.avsystem.justworks.core.model.ApiSpec
+import com.avsystem.justworks.core.model.EnumBackingType
+import com.avsystem.justworks.core.model.PropertyModel
+import com.avsystem.justworks.core.model.SchemaModel
+import com.avsystem.justworks.core.model.TypeRef
+import com.squareup.kotlinpoet.TypeSpec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ModelGeneratorInlineEnumTest {
+    private val modelPackage = "com.example.model"
+
+    private fun generate(spec: ApiSpec) = context(
+        Hierarchy(ModelPackage(modelPackage)).apply { addSchemas(spec.schemas) },
+        NameRegistry(),
+    ) {
+        ModelGenerator.generate(spec)
+    }
+
+    private val inlineEnumSchema = SchemaModel(
+        name = "ExecuteSpeedTestRequest",
+        description = null,
+        properties = listOf(
+            PropertyModel(
+                name = "measurements",
+                type = TypeRef.Array(
+                    TypeRef.InlineEnum(
+                        values = listOf("DownloadSpeed", "UploadSpeed"),
+                        backingType = EnumBackingType.STRING,
+                        contextHint = "ExecuteSpeedTestRequest.MeasurementsItem",
+                    ),
+                ),
+                description = null,
+                nullable = true,
+            ),
+        ),
+        requiredProperties = emptySet(),
+        allOf = null,
+        oneOf = null,
+        anyOf = null,
+        discriminator = null,
+    )
+
+    @Test
+    fun `inline enum in array items generates a typed enum class`() {
+        val files = generate(
+            ApiSpec("Test", "1.0", emptyList(), listOf(inlineEnumSchema), emptyList(), emptyList()),
+        )
+
+        val enumName = "ExecuteSpeedTestRequest_MeasurementsItem"
+        val enumType = files
+            .flatMap { it.members.filterIsInstance<TypeSpec>() }
+            .find { it.name == enumName }
+        assertNotNull(enumType, "Expected generated enum '$enumName'")
+        assertEquals(
+            setOf("DOWNLOAD_SPEED", "UPLOAD_SPEED"),
+            enumType.enumConstants.keys,
+        )
+    }
+
+    @Test
+    fun `property references the generated enum instead of String`() {
+        val files = generate(
+            ApiSpec("Test", "1.0", emptyList(), listOf(inlineEnumSchema), emptyList(), emptyList()),
+        )
+
+        val dataClass = files
+            .flatMap { it.members.filterIsInstance<TypeSpec>() }
+            .find { it.name == "ExecuteSpeedTestRequest" }
+        assertNotNull(dataClass, "Expected data class")
+        val measurements = dataClass.propertySpecs.first { it.name == "measurements" }
+        val typeString = measurements.type.toString()
+        assertTrue(
+            typeString.contains("ExecuteSpeedTestRequest_MeasurementsItem"),
+            "Expected property to reference generated enum, got: $typeString",
+        )
+    }
+}

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorInlineEnumTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorInlineEnumTest.kt
@@ -80,4 +80,222 @@ class ModelGeneratorInlineEnumTest {
             "Expected property to reference generated enum, got: $typeString",
         )
     }
+
+    @Test
+    fun `two properties with identical inline enums dedup to a single generated enum`() {
+        val values = listOf("DownloadSpeed", "UploadSpeed")
+        val schema = SchemaModel(
+            name = "Request",
+            description = null,
+            properties = listOf(
+                PropertyModel(
+                    name = "primary",
+                    type = TypeRef.Array(
+                        TypeRef.InlineEnum(values, EnumBackingType.STRING, "Request.PrimaryItem"),
+                    ),
+                    description = null,
+                    nullable = true,
+                ),
+                PropertyModel(
+                    name = "secondary",
+                    type = TypeRef.Array(
+                        TypeRef.InlineEnum(values, EnumBackingType.STRING, "Request.SecondaryItem"),
+                    ),
+                    description = null,
+                    nullable = true,
+                ),
+            ),
+            requiredProperties = emptySet(),
+            allOf = null,
+            oneOf = null,
+            anyOf = null,
+            discriminator = null,
+        )
+
+        val files = generate(
+            ApiSpec("Test", "1.0", emptyList(), listOf(schema), emptyList(), emptyList()),
+        )
+
+        val enums = files
+            .flatMap { it.members.filterIsInstance<TypeSpec>() }
+            .filter { it.enumConstants.isNotEmpty() }
+        assertEquals(1, enums.size, "Expected exactly one generated enum, got: ${enums.map { it.name }}")
+
+        // Both properties reference the same generated enum.
+        val dataClass = files
+            .flatMap { it.members.filterIsInstance<TypeSpec>() }
+            .first { it.name == "Request" }
+        val enumName = enums.single().name
+        assertNotNull(enumName)
+        dataClass.propertySpecs.forEach { prop ->
+            assertTrue(
+                prop.type.toString().contains(enumName),
+                "Expected '${prop.name}' to reference '$enumName', got: ${prop.type}",
+            )
+        }
+    }
+
+    @Test
+    fun `inline schemas differing only in a nested enum contextHint dedup to one`() {
+        fun wrapper(enumHint: String, propHint: String) = TypeRef.Inline(
+            properties = listOf(
+                PropertyModel(
+                    name = "mode",
+                    type = TypeRef.InlineEnum(
+                        values = listOf("Fast", "Slow"),
+                        backingType = EnumBackingType.STRING,
+                        contextHint = enumHint,
+                    ),
+                    description = null,
+                    nullable = false,
+                ),
+            ),
+            requiredProperties = setOf("mode"),
+            contextHint = propHint,
+        )
+
+        val schema = SchemaModel(
+            name = "Request",
+            description = null,
+            properties = listOf(
+                PropertyModel("a", wrapper("Request.A.Mode", "Request.A"), null, false),
+                PropertyModel("b", wrapper("Request.B.Mode", "Request.B"), null, false),
+            ),
+            requiredProperties = emptySet(),
+            allOf = null,
+            oneOf = null,
+            anyOf = null,
+            discriminator = null,
+        )
+
+        val files = generate(
+            ApiSpec("Test", "1.0", emptyList(), listOf(schema), emptyList(), emptyList()),
+        )
+
+        val types = files.flatMap { it.members.filterIsInstance<TypeSpec>() }
+        // One wrapper data class (the nested inline schema) + one enum, despite two properties.
+        val wrappers = types.filter { it.name != "Request" && it.enumConstants.isEmpty() }
+        val enums = types.filter { it.enumConstants.isNotEmpty() }
+        assertEquals(1, wrappers.size, "Expected one deduped inline schema, got: ${wrappers.map { it.name }}")
+        assertEquals(1, enums.size, "Expected one deduped inline enum, got: ${enums.map { it.name }}")
+    }
+
+    @Test
+    fun `integer-backed inline enum generates a typed enum class`() {
+        val schema = SchemaModel(
+            name = "Request",
+            description = null,
+            properties = listOf(
+                PropertyModel(
+                    name = "codes",
+                    type = TypeRef.Array(
+                        TypeRef.InlineEnum(
+                            values = listOf("100", "200"),
+                            backingType = EnumBackingType.INTEGER,
+                            contextHint = "Request.CodesItem",
+                        ),
+                    ),
+                    description = null,
+                    nullable = true,
+                ),
+            ),
+            requiredProperties = emptySet(),
+            allOf = null,
+            oneOf = null,
+            anyOf = null,
+            discriminator = null,
+        )
+
+        val files = generate(
+            ApiSpec("Test", "1.0", emptyList(), listOf(schema), emptyList(), emptyList()),
+        )
+
+        val enumType = files
+            .flatMap { it.members.filterIsInstance<TypeSpec>() }
+            .find { it.name == "Request_CodesItem" }
+        assertNotNull(enumType, "Expected generated enum 'Request_CodesItem'")
+        assertEquals(setOf("100", "200"), enumType.enumConstants.keys)
+    }
+
+    @Test
+    fun `inline enum directly on a property generates a typed enum class`() {
+        val schema = SchemaModel(
+            name = "Request",
+            description = null,
+            properties = listOf(
+                PropertyModel(
+                    name = "status",
+                    type = TypeRef.InlineEnum(
+                        values = listOf("Active", "Inactive"),
+                        backingType = EnumBackingType.STRING,
+                        contextHint = "Request.Status",
+                    ),
+                    description = null,
+                    nullable = false,
+                ),
+            ),
+            requiredProperties = setOf("status"),
+            allOf = null,
+            oneOf = null,
+            anyOf = null,
+            discriminator = null,
+        )
+
+        val files = generate(
+            ApiSpec("Test", "1.0", emptyList(), listOf(schema), emptyList(), emptyList()),
+        )
+
+        val types = files.flatMap { it.members.filterIsInstance<TypeSpec>() }
+        val enumType = types.find { it.name == "Request_Status" }
+        assertNotNull(enumType, "Expected generated enum 'Request_Status'")
+        assertEquals(setOf("ACTIVE", "INACTIVE"), enumType.enumConstants.keys)
+
+        val status = types.first { it.name == "Request" }.propertySpecs.first { it.name == "status" }
+        assertTrue(
+            status.type.toString().contains("Request_Status"),
+            "Expected property to reference generated enum, got: ${status.type}",
+        )
+    }
+
+    @Test
+    fun `inline enum as a map value generates a typed enum class`() {
+        val schema = SchemaModel(
+            name = "Request",
+            description = null,
+            properties = listOf(
+                PropertyModel(
+                    name = "byRegion",
+                    type = TypeRef.Map(
+                        TypeRef.InlineEnum(
+                            values = listOf("Eu", "Us"),
+                            backingType = EnumBackingType.STRING,
+                            contextHint = "Request.ByRegionValue",
+                        ),
+                    ),
+                    description = null,
+                    nullable = true,
+                ),
+            ),
+            requiredProperties = emptySet(),
+            allOf = null,
+            oneOf = null,
+            anyOf = null,
+            discriminator = null,
+        )
+
+        val files = generate(
+            ApiSpec("Test", "1.0", emptyList(), listOf(schema), emptyList(), emptyList()),
+        )
+
+        val types = files.flatMap { it.members.filterIsInstance<TypeSpec>() }
+        val enumType = types.find { it.name == "Request_ByRegionValue" }
+        assertNotNull(enumType, "Expected generated enum 'Request_ByRegionValue'")
+        assertEquals(setOf("EU", "US"), enumType.enumConstants.keys)
+
+        val byRegion = types.first { it.name == "Request" }.propertySpecs.first { it.name == "byRegion" }
+        assertTrue(
+            byRegion.type.toString().contains("Request_ByRegionValue"),
+            "Expected map value to reference generated enum, got: ${byRegion.type}",
+        )
+    }
 }

--- a/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserInlineEnumTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserInlineEnumTest.kt
@@ -27,4 +27,31 @@ class SpecParserInlineEnumTest : SpecParserTestBase() {
         assertEquals(listOf("DownloadSpeed", "UploadSpeed"), inlineEnum.values)
         assertEquals(EnumBackingType.STRING, inlineEnum.backingType)
     }
+
+    @Test
+    fun `inline enum as a map value carries a context-derived hint`() {
+        val spec = parseSpec(loadResource("inline-enum-spec.yaml"))
+
+        val schema = assertNotNull(
+            spec.schemas.find { it.name == "SpeedTestResult" },
+            "SpeedTestResult schema missing",
+        )
+
+        fun mapValueEnum(propName: String): TypeRef.InlineEnum {
+            val prop = assertNotNull(
+                schema.properties.find { it.name == propName },
+                "$propName property missing",
+            )
+            val map = assertIs<TypeRef.Map>(prop.type)
+            return assertIs<TypeRef.InlineEnum>(map.valueType)
+        }
+
+        val flags = mapValueEnum("flagsByRegion")
+        assertEquals(listOf("ENABLED", "DISABLED"), flags.values)
+        assertEquals("SpeedTestResult.FlagsByRegionValue", flags.contextHint)
+
+        val tiers = mapValueEnum("tiersByUser")
+        assertEquals(listOf("FREE", "PRO"), tiers.values)
+        assertEquals("SpeedTestResult.TiersByUserValue", tiers.contextHint)
+    }
 }

--- a/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserInlineEnumTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserInlineEnumTest.kt
@@ -1,0 +1,30 @@
+package com.avsystem.justworks.core.parser
+
+import com.avsystem.justworks.core.model.EnumBackingType
+import com.avsystem.justworks.core.model.TypeRef
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class SpecParserInlineEnumTest : SpecParserTestBase() {
+    @Test
+    fun `inline enum in array items is parsed as InlineEnum`() {
+        val spec = parseSpec(loadResource("inline-enum-spec.yaml"))
+
+        val schema = assertNotNull(
+            spec.schemas.find { it.name == "ExecuteSpeedTestRequest" },
+            "ExecuteSpeedTestRequest schema missing",
+        )
+        val measurements = assertNotNull(
+            schema.properties.find { it.name == "measurements" },
+            "measurements property missing",
+        )
+
+        val array = assertIs<TypeRef.Array>(measurements.type)
+        val inlineEnum = assertIs<TypeRef.InlineEnum>(array.items)
+
+        assertEquals(listOf("DownloadSpeed", "UploadSpeed"), inlineEnum.values)
+        assertEquals(EnumBackingType.STRING, inlineEnum.backingType)
+    }
+}

--- a/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserTest.kt
@@ -865,7 +865,7 @@ class SpecParserTest : SpecParserTestBase() {
                 }
             }
 
-            is TypeRef.Primitive, TypeRef.Unknown, null -> {}
+            is TypeRef.Primitive, is TypeRef.InlineEnum, TypeRef.Unknown, null -> {}
         }
     }
 }

--- a/core/src/test/resources/inline-enum-spec.yaml
+++ b/core/src/test/resources/inline-enum-spec.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Inline Enum Test
+  version: 1.0.0
+paths:
+  /speedtest:
+    post:
+      operationId: executeSpeedTest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExecuteSpeedTestRequest'
+      responses:
+        '200':
+          description: ok
+components:
+  schemas:
+    ExecuteSpeedTestRequest:
+      type: object
+      properties:
+        measurements:
+          type: array
+          items:
+            type: string
+            enum:
+              - DownloadSpeed
+              - UploadSpeed
+          uniqueItems: true
+          default:
+            - DownloadSpeed
+            - UploadSpeed

--- a/core/src/test/resources/inline-enum-spec.yaml
+++ b/core/src/test/resources/inline-enum-spec.yaml
@@ -31,3 +31,20 @@ components:
           default:
             - DownloadSpeed
             - UploadSpeed
+    SpeedTestResult:
+      type: object
+      properties:
+        flagsByRegion:
+          type: object
+          additionalProperties:
+            type: string
+            enum:
+              - ENABLED
+              - DISABLED
+        tiersByUser:
+          type: object
+          additionalProperties:
+            type: string
+            enum:
+              - FREE
+              - PRO


### PR DESCRIPTION
## Summary

Fixes #74. Inline enums declared directly in array `items` (or inline on a property) were generated as plain `String`, losing both the enum values and type safety.

### Before
```kotlin
public val measurements: List<String>? = null
```

### After
```kotlin
@Serializable
public enum class ExecuteSpeedTestRequest_MeasurementsItem {
    @SerialName("DownloadSpeed") DOWNLOAD_SPEED,
    @SerialName("UploadSpeed") UPLOAD_SPEED,
}
// ...
public val measurements: List<ExecuteSpeedTestRequest_MeasurementsItem>? = null
```

## Changes

- New `TypeRef.InlineEnum` variant.
- `SpecParser` emits `InlineEnum` for enum schemas that are not named components (named component enums still resolve to `Reference`). Null enum entries (nullable markers) are filtered.
- `ModelGenerator` collects inline enums, deduplicates structurally (`InlineEnumKey`), registers names via the shared `NameRegistry`, generates an `EnumModel`, and resolves references — mirroring inline-object handling.
- The duplicated collect → dedup → name → model pipeline for inline objects and enums is unified into `collectInlineDefinitions` + `topLevelTypeRefs`.

## Tests

- `SpecParserInlineEnumTest` — parser produces `Array(InlineEnum)` from the spec.
- `ModelGeneratorInlineEnumTest` — a typed enum class is generated and the property references it.
- Naming follows the existing inline convention (`<Parent>_<Property>Item`).

## Out of scope (separate follow-ups, noted in #74)

- `uniqueItems: true` still maps to `List` (not `Set`).
- Array `default` is still dropped (nullable property defaults to `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)