### PR TITLE
fix(core): honor property defaults instead of dropping them to null

### DIFF
--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -60,6 +60,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.WildcardTypeName
 import com.squareup.kotlinpoet.joinToCode
 import kotlinx.datetime.LocalDate
+import java.util.Base64
 import kotlin.time.Instant
 
 /**
@@ -477,40 +478,76 @@ internal object ModelGenerator {
     private fun formatDefaultValue(
         type: TypeRef,
         value: Any?,
-        propName: String
+        propName: String,
     ): CodeBlock = when (type) {
         is TypeRef.Primitive -> {
             when (type.type) {
-                PrimitiveType.STRING -> CodeBlock.of("%S", value)
+                PrimitiveType.STRING -> {
+                    CodeBlock.of("%S", value)
+                }
 
                 PrimitiveType.INT,
                 PrimitiveType.LONG,
                 PrimitiveType.DOUBLE,
-                PrimitiveType.FLOAT,
                 PrimitiveType.BOOLEAN,
-                -> CodeBlock.of("%L", value)
+                -> {
+                    CodeBlock.of("%L", value)
+                }
 
-                PrimitiveType.DATE_TIME -> catch(
-                    { Instant.parse(value as String) },
-                    { CodeBlock.of("%T.parse(%S)", INSTANT, value) },
-                    { e ->
-                        throw IllegalArgumentException(
-                            "Invalid ISO-8601 date-time default '$value' for property $propName: ${e.message}",
+                PrimitiveType.FLOAT -> {
+                    CodeBlock.of("%Lf", value)
+                }
+
+                PrimitiveType.DATE_TIME -> {
+                    catch(
+                        { Instant.parse(value as String) },
+                        { CodeBlock.of("%T.parse(%S)", INSTANT, value) },
+                        { e ->
+                            throw IllegalArgumentException(
+                                "Invalid ISO-8601 date-time default '$value' for property $propName: ${e.message}",
+                            )
+                        },
+                    )
+                }
+
+                PrimitiveType.DATE -> {
+                    catch(
+                        { LocalDate.parse(value as String) },
+                        { CodeBlock.of("%T.parse(%S)", LOCAL_DATE, value) },
+                        { e ->
+                            throw IllegalArgumentException(
+                                "Invalid ISO-8601 date default '$value' for property $propName: ${e.message}",
+                            )
+                        },
+                    )
+                }
+
+                PrimitiveType.BYTE_ARRAY -> {
+                    val bytes = when (value) {
+                        is ByteArray -> value
+
+                        is String -> catch(
+                            {
+                                Base64.getDecoder().decode(value)
+                            },
+                            { it },
+                            { e ->
+                                throw IllegalArgumentException(
+                                    "Invalid base64 byte default '$value' for property $propName: ${e.message}",
+                                )
+                            },
                         )
-                    },
-                )
 
-                PrimitiveType.DATE -> catch(
-                    { LocalDate.parse(value as String) },
-                    { CodeBlock.of("%T.parse(%S)", LOCAL_DATE, value) },
-                    { e ->
-                        throw IllegalArgumentException(
-                            "Invalid ISO-8601 date default '$value' for property $propName: ${e.message}",
+                        else -> throw IllegalArgumentException(
+                            "Unsupported byte-array default '$value' for property $propName",
                         )
-                    },
-                )
+                    }
+                    CodeBlock.of("byteArrayOf(%L)", bytes.joinToString(", "))
+                }
 
-                else -> throw IllegalArgumentException("Unsupported default value type: $type")
+                PrimitiveType.UUID -> {
+                    throw IllegalArgumentException("Unsupported default value type: $type")
+                }
             }
         }
 

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -58,6 +58,7 @@ import com.squareup.kotlinpoet.TypeAliasSpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.WildcardTypeName
+import com.squareup.kotlinpoet.joinToCode
 import kotlinx.datetime.LocalDate
 import kotlin.time.Instant
 
@@ -469,49 +470,67 @@ internal object ModelGenerator {
      */
 
     context(hierarchy: Hierarchy)
-    private fun formatDefaultValue(prop: PropertyModel): CodeBlock = when (prop.type) {
+    private fun formatDefaultValue(prop: PropertyModel): CodeBlock =
+        formatDefaultValue(prop.type, prop.defaultValue, prop.name)
+
+    context(hierarchy: Hierarchy)
+    private fun formatDefaultValue(
+        type: TypeRef,
+        value: Any?,
+        propName: String
+    ): CodeBlock = when (type) {
         is TypeRef.Primitive -> {
-            when (prop.type.type) {
-                PrimitiveType.STRING -> CodeBlock.of("%S", prop.defaultValue)
+            when (type.type) {
+                PrimitiveType.STRING -> CodeBlock.of("%S", value)
 
                 PrimitiveType.INT,
                 PrimitiveType.LONG,
                 PrimitiveType.DOUBLE,
                 PrimitiveType.FLOAT,
                 PrimitiveType.BOOLEAN,
-                -> CodeBlock.of("%L", prop.defaultValue)
+                -> CodeBlock.of("%L", value)
 
                 PrimitiveType.DATE_TIME -> catch(
-                    { Instant.parse(prop.defaultValue as String) },
-                    { CodeBlock.of("%T.parse(%S)", INSTANT, prop.defaultValue) },
+                    { Instant.parse(value as String) },
+                    { CodeBlock.of("%T.parse(%S)", INSTANT, value) },
                     { e ->
                         throw IllegalArgumentException(
-                            "Invalid ISO-8601 date-time default '${prop.defaultValue}' for property ${prop.name}: ${e.message}",
+                            "Invalid ISO-8601 date-time default '$value' for property $propName: ${e.message}",
                         )
                     },
                 )
 
                 PrimitiveType.DATE -> catch(
-                    { LocalDate.parse(prop.defaultValue as String) },
-                    { CodeBlock.of("%T.parse(%S)", LOCAL_DATE, prop.defaultValue) },
+                    { LocalDate.parse(value as String) },
+                    { CodeBlock.of("%T.parse(%S)", LOCAL_DATE, value) },
                     { e ->
                         throw IllegalArgumentException(
-                            "Invalid ISO-8601 date default '${prop.defaultValue}' for property ${prop.name}: ${e.message}",
+                            "Invalid ISO-8601 date default '$value' for property $propName: ${e.message}",
                         )
                     },
                 )
 
-                else -> throw IllegalArgumentException("Unsupported default value type: ${prop.type}")
+                else -> throw IllegalArgumentException("Unsupported default value type: $type")
             }
         }
 
         is TypeRef.Reference -> {
-            val constantName = prop.defaultValue.toString().toEnumConstantName()
-            CodeBlock.of("%T.%L", ClassName(hierarchy.modelPackage, prop.type.schemaName), constantName)
+            val constantName = value.toString().toEnumConstantName()
+            CodeBlock.of("%T.%L", ClassName(hierarchy.modelPackage, type.schemaName), constantName)
+        }
+
+        is TypeRef.Array -> {
+            val elements = (value as? List<*>).orEmpty()
+            if (elements.isEmpty()) {
+                CodeBlock.of("emptyList()")
+            } else {
+                val items = elements.map { formatDefaultValue(type.items, it, propName) }
+                CodeBlock.of("listOf(%L)", items.joinToCode(separator = ", "))
+            }
         }
 
         else -> {
-            throw IllegalArgumentException("Unsupported default value type: ${prop.type}")
+            throw IllegalArgumentException("Unsupported default value type: $type")
         }
     }
 

--- a/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
@@ -517,7 +517,7 @@ object SpecParser {
         when (this) {
             is TypeRef.Primitive, is TypeRef.InlineEnum, is TypeRef.Reference -> true
             is TypeRef.Array -> items.honorsDefault(default)
-            else -> false
+            is TypeRef.Inline, is TypeRef.Map, TypeRef.Unknown -> false
         }
 
     /**
@@ -529,9 +529,17 @@ object SpecParser {
         is ArrayNode -> default.map { normalizeDefault(it) }
 
         is JsonNode -> when {
-            default.isBoolean -> default.booleanValue()
+            default.isShort -> default.shortValue()
             default.isInt -> default.intValue()
-            default.isNumber -> default.doubleValue()
+            default.isLong -> default.longValue()
+            default.isFloat -> default.floatValue()
+            default.isDouble -> default.doubleValue()
+            default.isBigDecimal -> default.decimalValue()
+            default.isBigInteger -> default.bigIntegerValue()
+            default.isNumber -> default.numberValue()
+            default.isBoolean -> default.booleanValue()
+            default.isNull -> null
+            default.isBinary -> default.binaryValue()
             else -> default.asText()
         }
 

--- a/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
@@ -36,6 +36,8 @@ import com.avsystem.justworks.core.model.SchemaModel
 import com.avsystem.justworks.core.model.SecurityScheme
 import com.avsystem.justworks.core.model.TypeRef
 import com.avsystem.justworks.core.toEnumOrNull
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.PathItem
@@ -503,6 +505,40 @@ object SpecParser {
     private val Schema<*>.isEnumSchema get(): Boolean = !enum.isNullOrEmpty()
 
     /**
+     * True when a property of this type declares a `default` that should be honored, i.e. the
+     * property is not optional-null but carries a concrete value and must be generated as a
+     * non-nullable field initialized to that default rather than as `T? = null`.
+     *
+     * Honored for scalar/enum types (primitives, inline enums, references — the latter typically
+     * a named enum) and for arrays of such element types (emitted as `listOf(...)`/`emptyList()`).
+     * Object/map defaults are intentionally excluded and keep the previous nullable-null behavior.
+     */
+    private fun TypeRef.honorsDefault(default: Any?): Boolean = default != null &&
+        when (this) {
+            is TypeRef.Primitive, is TypeRef.InlineEnum, is TypeRef.Reference -> true
+            is TypeRef.Array -> items.honorsDefault(default)
+            else -> false
+        }
+
+    /**
+     * Normalizes a raw Swagger default into a plain Kotlin value the model layer can format
+     * without depending on Jackson. Array defaults arrive as a Jackson [ArrayNode]; unwrap them
+     * into a `List` of plain scalar values. Scalar defaults are already plain and pass through.
+     */
+    private fun normalizeDefault(default: Any?): Any? = when (default) {
+        is ArrayNode -> default.map { normalizeDefault(it) }
+
+        is JsonNode -> when {
+            default.isBoolean -> default.booleanValue()
+            default.isInt -> default.intValue()
+            default.isNumber -> default.doubleValue()
+            else -> default.asText()
+        }
+
+        else -> default
+    }
+
+    /**
      * Builds a [TypeRef.InlineEnum] for an enum schema that is not a named component
      * (e.g. an enum declared directly in array `items` or inline on a property).
      * Named component enums are resolved to [TypeRef.Reference] before reaching here.
@@ -521,12 +557,13 @@ object SpecParser {
         properties
             .orEmpty()
             .mapValues { (propName, propSchema) ->
+                val type = propSchema.toTypeRef(createContext(propName))
                 PropertyModel(
                     name = propName,
-                    type = propSchema.toTypeRef(createContext(propName)),
+                    type = type,
                     description = propSchema.description,
-                    nullable = propName !in required,
-                    defaultValue = propSchema.default,
+                    nullable = propName !in required && !type.honorsDefault(propSchema.default),
+                    defaultValue = normalizeDefault(propSchema.default),
                 )
             }
 

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorTest.kt
@@ -16,6 +16,7 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -628,6 +629,294 @@ class ModelGeneratorTest {
             param.defaultValue.toString().contains("Status.ACTIVE"),
             "Expected Status.ACTIVE, got: ${param.defaultValue}",
         )
+    }
+
+    @Test
+    fun `array property with default emits listOf with element literals`() {
+        val schema =
+            SchemaModel(
+                name = "Config",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "tags",
+                            TypeRef.Array(TypeRef.Primitive(PrimitiveType.STRING)),
+                            null,
+                            false,
+                            listOf("X", "Y"),
+                        ),
+                    ),
+                requiredProperties = setOf("tags"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(schema)))
+        val typeSpec = files[0].members.filterIsInstance<TypeSpec>()[0]
+        val constructor = assertNotNull(typeSpec.primaryConstructor)
+        val param = constructor.parameters.first { it.name == "tags" }
+        assertEquals("listOf(\"X\", \"Y\")", param.defaultValue.toString())
+    }
+
+    @Test
+    fun `array property with empty default emits emptyList`() {
+        val schema =
+            SchemaModel(
+                name = "Config",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "tags",
+                            TypeRef.Array(TypeRef.Primitive(PrimitiveType.STRING)),
+                            null,
+                            false,
+                            emptyList<String>(),
+                        ),
+                    ),
+                requiredProperties = setOf("tags"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(schema)))
+        val typeSpec = files[0].members.filterIsInstance<TypeSpec>()[0]
+        val constructor = assertNotNull(typeSpec.primaryConstructor)
+        val param = constructor.parameters.first { it.name == "tags" }
+        assertEquals("emptyList()", param.defaultValue.toString())
+    }
+
+    @Test
+    fun `long default generates default parameter with literal`() {
+        val schema =
+            SchemaModel(
+                name = "Config",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel("count", TypeRef.Primitive(PrimitiveType.LONG), null, false, 9999999999L),
+                    ),
+                requiredProperties = setOf("count"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(schema)))
+        val typeSpec = files[0].members.filterIsInstance<TypeSpec>()[0]
+        val constructor = assertNotNull(typeSpec.primaryConstructor)
+        val param = constructor.parameters.first { it.name == "count" }
+        assertEquals("9_999_999_999", param.defaultValue.toString())
+    }
+
+    @Test
+    fun `float default generates default parameter with literal`() {
+        val schema =
+            SchemaModel(
+                name = "Config",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel("ratio", TypeRef.Primitive(PrimitiveType.FLOAT), null, false, 1.5f),
+                    ),
+                requiredProperties = setOf("ratio"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(schema)))
+        val typeSpec = files[0].members.filterIsInstance<TypeSpec>()[0]
+        val constructor = assertNotNull(typeSpec.primaryConstructor)
+        val param = constructor.parameters.first { it.name == "ratio" }
+        assertEquals("1.5f", param.defaultValue.toString())
+    }
+
+    @Test
+    fun `array of enum references default emits listOf with enum constants`() {
+        val statusEnum =
+            EnumModel(
+                name = "Status",
+                description = null,
+                type = EnumBackingType.STRING,
+                values = listOf(EnumModel.Value("active"), EnumModel.Value("closed")),
+            )
+        val schema =
+            SchemaModel(
+                name = "Task",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "statuses",
+                            TypeRef.Array(TypeRef.Reference("Status")),
+                            null,
+                            false,
+                            listOf("active", "closed"),
+                        ),
+                    ),
+                requiredProperties = setOf("statuses"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(schema), enums = listOf(statusEnum)))
+        val typeSpec = files.first { it.name == "Task" }.members.filterIsInstance<TypeSpec>()[0]
+        val constructor = assertNotNull(typeSpec.primaryConstructor)
+        val param = constructor.parameters.first { it.name == "statuses" }
+        assertEquals(
+            "listOf(com.example.model.Status.ACTIVE, com.example.model.Status.CLOSED)",
+            param.defaultValue.toString(),
+        )
+    }
+
+    @Test
+    fun `invalid date-time default throws IllegalArgumentException`() {
+        val schema =
+            SchemaModel(
+                name = "Event",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "createdAt",
+                            TypeRef.Primitive(PrimitiveType.DATE_TIME),
+                            null,
+                            false,
+                            "not-a-date",
+                        ),
+                    ),
+                requiredProperties = setOf("createdAt"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val ex = assertFailsWith<IllegalArgumentException> { generate(spec(schemas = listOf(schema))) }
+        assertTrue(ex.message!!.contains("createdAt"), "Expected property name in message, got: ${ex.message}")
+    }
+
+    @Test
+    fun `invalid date default throws IllegalArgumentException`() {
+        val schema =
+            SchemaModel(
+                name = "Event",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel("eventDate", TypeRef.Primitive(PrimitiveType.DATE), null, false, "not-a-date"),
+                    ),
+                requiredProperties = setOf("eventDate"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val ex = assertFailsWith<IllegalArgumentException> { generate(spec(schemas = listOf(schema))) }
+        assertTrue(ex.message!!.contains("eventDate"), "Expected property name in message, got: ${ex.message}")
+    }
+
+    @Test
+    fun `unsupported primitive default type throws IllegalArgumentException`() {
+        val schema =
+            SchemaModel(
+                name = "Config",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel("id", TypeRef.Primitive(PrimitiveType.UUID), null, false, "some-uuid"),
+                    ),
+                requiredProperties = setOf("id"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        assertFailsWith<IllegalArgumentException> { generate(spec(schemas = listOf(schema))) }
+    }
+
+    @Test
+    fun `byte array default from base64 string emits byteArrayOf literal`() {
+        // "AAEC" base64-decodes to bytes 0, 1, 2
+        val schema =
+            SchemaModel(
+                name = "Blob",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel("data", TypeRef.Primitive(PrimitiveType.BYTE_ARRAY), null, false, "AAEC"),
+                    ),
+                requiredProperties = setOf("data"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(schema)))
+        val typeSpec = files[0].members.filterIsInstance<TypeSpec>()[0]
+        val constructor = assertNotNull(typeSpec.primaryConstructor)
+        val param = constructor.parameters.first { it.name == "data" }
+        assertEquals("byteArrayOf(0, 1, 2)", param.defaultValue.toString())
+    }
+
+    @Test
+    fun `byte array default from decoded ByteArray emits byteArrayOf literal`() {
+        // Jackson binary nodes arrive already decoded as a ByteArray
+        val schema =
+            SchemaModel(
+                name = "Blob",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "data",
+                            TypeRef.Primitive(PrimitiveType.BYTE_ARRAY),
+                            null,
+                            false,
+                            byteArrayOf(10, -1, 127),
+                        ),
+                    ),
+                requiredProperties = setOf("data"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(schema)))
+        val typeSpec = files[0].members.filterIsInstance<TypeSpec>()[0]
+        val constructor = assertNotNull(typeSpec.primaryConstructor)
+        val param = constructor.parameters.first { it.name == "data" }
+        assertEquals("byteArrayOf(10, -1, 127)", param.defaultValue.toString())
+    }
+
+    @Test
+    fun `invalid base64 byte array default throws IllegalArgumentException`() {
+        val schema =
+            SchemaModel(
+                name = "Blob",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "data",
+                            TypeRef.Primitive(PrimitiveType.BYTE_ARRAY),
+                            null,
+                            false,
+                            "!!!not-base64!!!",
+                        ),
+                    ),
+                requiredProperties = setOf("data"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val ex = assertFailsWith<IllegalArgumentException> { generate(spec(schemas = listOf(schema))) }
+        assertTrue(ex.message!!.contains("data"), "Expected property name in message, got: ${ex.message}")
     }
 
     // -- Primitive-only type alias tests --

--- a/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserDefaultsTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserDefaultsTest.kt
@@ -1,0 +1,49 @@
+package com.avsystem.justworks.core.parser
+
+import com.avsystem.justworks.core.model.ApiSpec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * A property that declares a `default` is not optional-null: it must be parsed as a non-nullable
+ * field carrying that default value. Covers scalar, enum, and array defaults; properties without a
+ * default stay nullable. See [SpecParser.honorsDefault].
+ */
+class SpecParserDefaultsTest : SpecParserTestBase() {
+    private val defaults: ApiSpec = parseSpec(loadResource("fixtures/property-defaults-spec.json"))
+
+    private val props get() = defaults.schemas
+        .first { it.name == "Defaults" }
+        .properties
+        .associateBy { it.name }
+
+    @Test
+    fun `scalar enum default makes property non-nullable and keeps the value`() {
+        val mode = props.getValue("mode")
+        assertFalse(mode.nullable, "property with a default must not be nullable")
+        assertEquals("B", mode.defaultValue)
+    }
+
+    @Test
+    fun `numeric default makes property non-nullable and keeps the value`() {
+        val retries = props.getValue("retries")
+        assertFalse(retries.nullable)
+        assertEquals(3, retries.defaultValue)
+    }
+
+    @Test
+    fun `array default is normalized to a plain List and property is non-nullable`() {
+        val tags = props.getValue("tags")
+        assertFalse(tags.nullable)
+        assertEquals(listOf("X", "Y"), tags.defaultValue)
+    }
+
+    @Test
+    fun `property without a default stays nullable`() {
+        val note = props.getValue("note")
+        assertTrue(note.nullable)
+        assertEquals(null, note.defaultValue)
+    }
+}

--- a/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserDefaultsTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserDefaultsTest.kt
@@ -4,6 +4,7 @@ import com.avsystem.justworks.core.model.ApiSpec
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -45,5 +46,19 @@ class SpecParserDefaultsTest : SpecParserTestBase() {
         val note = props.getValue("note")
         assertTrue(note.nullable)
         assertEquals(null, note.defaultValue)
+    }
+
+    @Test
+    fun `explicit null default is not honored and property stays nullable`() {
+        val nullDefault = props.getValue("nullDefault")
+        assertTrue(nullDefault.nullable, "explicit null default must not honor a value")
+        assertEquals(null, nullDefault.defaultValue)
+    }
+
+    @Test
+    fun `byte-array default makes property non-nullable and keeps the value`() {
+        val secret = props.getValue("secret")
+        assertFalse(secret.nullable, "property with a byte-array default must not be nullable")
+        assertNotNull(secret.defaultValue, "byte-array default value must be retained")
     }
 }

--- a/core/src/test/resources/fixtures/property-defaults-spec.json
+++ b/core/src/test/resources/fixtures/property-defaults-spec.json
@@ -1,0 +1,32 @@
+{
+  "openapi": "3.0.2",
+  "info": { "title": "defaults", "version": "1.0" },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Defaults": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["A", "B", "C"],
+            "default": "B"
+          },
+          "retries": {
+            "type": "integer",
+            "format": "int32",
+            "default": 3
+          },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string", "enum": ["X", "Y"] },
+            "default": ["X", "Y"]
+          },
+          "note": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/fixtures/property-defaults-spec.json
+++ b/core/src/test/resources/fixtures/property-defaults-spec.json
@@ -24,6 +24,15 @@
           },
           "note": {
             "type": "string"
+          },
+          "nullDefault": {
+            "type": "string",
+            "default": null
+          },
+          "secret": {
+            "type": "string",
+            "format": "byte",
+            "default": "AAEC"
           }
         }
       }


### PR DESCRIPTION
## Problem

A property that declares a JSON Schema `default` was being dropped. The parser marked every non-required property as nullable (`T? = null`), which discarded the declared default value entirely.

## Fix

A property with a `default` is not optional-null — it carries a concrete value, so it is now generated as a **non-nullable** field initialized to that default:

- scalar / enum / array defaults are honored
  - `mode: Mode = Mode.B`
  - `retries: Int = 3`
  - `tags: List<Tag> = listOf(Tag.X, Tag.Y)` / `emptyList()`
- array defaults arrive from the underlying parser as a Jackson `ArrayNode`; they are normalized to a plain `List` in the parser so the model layer stays Jackson-free
- object/map defaults are intentionally left unchanged for now (still nullable-null)

## Tests

New `SpecParserDefaultsTest` with a fixture covering scalar, enum, numeric, and array defaults, plus a property without a default (stays nullable). `:core:test` and `ktlintCheck` are green.
