### PR TITLE
fix(core): stop hoisting polymorphic discriminator into a dead enum

### DIFF
--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineCollector.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineCollector.kt
@@ -16,6 +16,41 @@ private fun ApiSpec.topLevelTypeRefs(): Sequence<TypeRef> {
     return (endpointRefs + schemaPropertyRefs).filterNotNull()
 }
 
+/**
+ * Drops the discriminator property from every polymorphic variant schema.
+ *
+ * In a sealed (oneOf/anyOf + discriminator) hierarchy the discriminator is emitted via
+ * `@SerialName`/`@JsonClassDiscriminator` on the subtype, never as a field — the variant's own
+ * (typically single-value) `type` property is dead weight. Removing it here keeps inline-enum
+ * collection, resolution, and generation consistent, so no orphan `*_Type` enum is hoisted.
+ *
+ * The @SerialName value comes from the parent's `discriminator.mapping`
+ * (see [com.avsystem.justworks.core.gen.resolveSerialName]), so dropping the field is lossless.
+ */
+internal fun ApiSpec.stripDiscriminatorProperties(): ApiSpec {
+    val discriminatorProps = discriminatorPropertyByVariant()
+    if (discriminatorProps.isEmpty()) return this
+    return copy(
+        schemas = schemas.map { schema ->
+            val discriminatorProp = discriminatorProps[schema.name] ?: return@map schema
+            schema.copy(properties = schema.properties.filterNot { it.name == discriminatorProp })
+        },
+    )
+}
+
+/**
+ * Maps each polymorphic variant schema name to the discriminator property it carries.
+ */
+private fun ApiSpec.discriminatorPropertyByVariant(): Map<String, String> = schemas
+    .asSequence()
+    .mapNotNull { parent -> parent.discriminator?.propertyName?.let { it to parent } }
+    .flatMap { (propertyName, parent) ->
+        (parent.oneOf.orEmpty() + parent.anyOf.orEmpty())
+            .asSequence()
+            .filterIsInstance<TypeRef.Reference>()
+            .map { it.schemaName to propertyName }
+    }.toMap()
+
 private val descendants = DeepRecursiveFunction<TypeRef, List<TypeRef>> { type ->
     listOf(type) + when (type) {
         is TypeRef.Inline -> type.properties.flatMap { callRecursive(it.type) }

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineCollector.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/InlineCollector.kt
@@ -28,28 +28,29 @@ private fun ApiSpec.topLevelTypeRefs(): Sequence<TypeRef> {
  * (see [com.avsystem.justworks.core.gen.resolveSerialName]), so dropping the field is lossless.
  */
 internal fun ApiSpec.stripDiscriminatorProperties(): ApiSpec {
-    val discriminatorProps = discriminatorPropertyByVariant()
-    if (discriminatorProps.isEmpty()) return this
-    return copy(
-        schemas = schemas.map { schema ->
-            val discriminatorProp = discriminatorProps[schema.name] ?: return@map schema
-            schema.copy(properties = schema.properties.filterNot { it.name == discriminatorProp })
-        },
-    )
-}
+    val discriminatorProps = schemas
+        .asSequence()
+        .mapNotNull { parent -> parent.discriminator?.propertyName?.let { it to parent } }
+        .flatMap { (propertyName, parent) ->
+            (parent.oneOf.orEmpty() + parent.anyOf.orEmpty())
+                .asSequence()
+                .filterIsInstance<TypeRef.Reference>()
+                .map { it.schemaName to propertyName }
+        }.toMap()
 
-/**
- * Maps each polymorphic variant schema name to the discriminator property it carries.
- */
-private fun ApiSpec.discriminatorPropertyByVariant(): Map<String, String> = schemas
-    .asSequence()
-    .mapNotNull { parent -> parent.discriminator?.propertyName?.let { it to parent } }
-    .flatMap { (propertyName, parent) ->
-        (parent.oneOf.orEmpty() + parent.anyOf.orEmpty())
-            .asSequence()
-            .filterIsInstance<TypeRef.Reference>()
-            .map { it.schemaName to propertyName }
-    }.toMap()
+    return if (discriminatorProps.isEmpty()) {
+        this
+    } else {
+        copy(
+            schemas = schemas.map { schema ->
+                when (val discriminatorProp = discriminatorProps[schema.name]) {
+                    null -> schema
+                    else -> schema.copy(properties = schema.properties.filterNot { it.name == discriminatorProp })
+                }
+            },
+        )
+    }
+}
 
 private val descendants = DeepRecursiveFunction<TypeRef, List<TypeRef>> { type ->
     listOf(type) + when (type) {

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -34,6 +34,7 @@ import com.avsystem.justworks.core.gen.resolveInlineTypes
 import com.avsystem.justworks.core.gen.resolveSerialName
 import com.avsystem.justworks.core.gen.resolveTypeRef
 import com.avsystem.justworks.core.gen.shared.SerializersModuleGenerator
+import com.avsystem.justworks.core.gen.stripDiscriminatorProperties
 import com.avsystem.justworks.core.gen.toCamelCase
 import com.avsystem.justworks.core.gen.toEnumConstantName
 import com.avsystem.justworks.core.gen.toPascalCase
@@ -74,7 +75,8 @@ internal object ModelGenerator {
     fun generate(spec: ApiSpec): List<FileSpec> = generateWithResolvedSpec(spec).files
 
     context(hierarchy: Hierarchy, nameRegistry: NameRegistry)
-    fun generateWithResolvedSpec(spec: ApiSpec): GenerateResult {
+    fun generateWithResolvedSpec(rawSpec: ApiSpec): GenerateResult {
+        val spec = rawSpec.stripDiscriminatorProperties()
         ensureReserved(spec, nameRegistry)
         val (inlineSchemas, nameMap) = collectInlineSchemas(spec)
         val (inlineEnums, enumNameMap) = collectInlineEnums(spec)

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -184,7 +184,6 @@ internal object ModelGenerator {
                 variantName = variantName,
                 parentClassName = className,
                 serialName = schema.resolveSerialName(variantName),
-                discriminatorProperty = schema.discriminator?.propertyName,
             )
             parentBuilder.addType(nestedType)
         }
@@ -213,22 +212,10 @@ internal object ModelGenerator {
         variantName: String,
         parentClassName: ClassName,
         serialName: String,
-        discriminatorProperty: String?,
     ): TypeSpec {
         val variantClassName = parentClassName.nestedClass(variantName.toPascalCase())
 
-        val filteredSchema = variantSchema?.let { schema ->
-            val properties = discriminatorProperty?.let { discriminatorProperty ->
-                schema.properties.filter { it.name != discriminatorProperty }
-            }
-            if (properties != null) {
-                schema.copy(properties = properties)
-            } else {
-                schema
-            }
-        }
-
-        val builder = if (filteredSchema?.properties.isNullOrEmpty()) {
+        val builder = if (variantSchema?.properties.isNullOrEmpty()) {
             TypeSpec.objectBuilder(variantClassName)
         } else {
             TypeSpec.classBuilder(variantClassName).addModifiers(KModifier.DATA)
@@ -238,8 +225,8 @@ internal object ModelGenerator {
         builder.addAnnotation(SERIALIZABLE)
         builder.addAnnotation(AnnotationSpec.builder(SERIAL_NAME).addMember("%S", serialName).build())
 
-        if (!filteredSchema?.properties.isNullOrEmpty()) {
-            buildConstructorAndProperties(filteredSchema, builder)
+        if (!variantSchema?.properties.isNullOrEmpty()) {
+            buildConstructorAndProperties(variantSchema, builder)
         }
 
         return builder.build()

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorPolymorphicTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorPolymorphicTest.kt
@@ -4,6 +4,7 @@ import com.avsystem.justworks.core.gen.model.ModelGenerator
 import com.avsystem.justworks.core.gen.toPascalCase
 import com.avsystem.justworks.core.model.ApiSpec
 import com.avsystem.justworks.core.model.Discriminator
+import com.avsystem.justworks.core.model.EnumBackingType
 import com.avsystem.justworks.core.model.EnumModel
 import com.avsystem.justworks.core.model.PrimitiveType
 import com.avsystem.justworks.core.model.PropertyModel
@@ -947,6 +948,67 @@ class ModelGeneratorPolymorphicTest {
             ClassName(modelPackage, "Circle"),
             result,
             "Should resolve Circle to flat ClassName without hierarchy entry",
+        )
+    }
+
+    @Test
+    fun `discriminator property is not hoisted into a standalone enum`() {
+        val animal =
+            schema(
+                name = "Animal",
+                oneOf = listOf(TypeRef.Reference("Cat")),
+                discriminator =
+                    Discriminator(
+                        propertyName = "type",
+                        mapping = mapOf("Cat" to "#/components/schemas/Cat"),
+                    ),
+            )
+        val cat =
+            schema(
+                name = "Cat",
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "type",
+                            TypeRef.InlineEnum(listOf("Cat"), EnumBackingType.STRING, "Cat.Type"),
+                            null,
+                            false,
+                        ),
+                        PropertyModel(
+                            "sound",
+                            TypeRef.InlineEnum(listOf("MEOW", "PURR"), EnumBackingType.STRING, "Cat.Sound"),
+                            null,
+                            false,
+                        ),
+                    ),
+            )
+
+        val files = generate(spec(schemas = listOf(animal, cat)))
+        val enumNames = files
+            .flatMap { it.members }
+            .filterIsInstance<TypeSpec>()
+            .filter { it.kind == TypeSpec.Kind.CLASS && KModifier.ENUM in it.modifiers }
+            .mapNotNull { it.name }
+
+        // The single-value `type` discriminator enum must NOT be generated...
+        assertTrue(
+            enumNames.none { it.contains("Type", ignoreCase = true) },
+            "Discriminator enum must not be hoisted, found: $enumNames",
+        )
+        // ...while a genuine non-discriminator inline enum on the variant still is.
+        assertTrue(
+            enumNames.any { it.contains("Sound", ignoreCase = true) },
+            "Non-discriminator inline enum should still be generated, found: $enumNames",
+        )
+
+        // The variant carries no `type` field (it is expressed via @SerialName instead).
+        val catType = findType(files, "Cat")
+        assertTrue(
+            catType.primaryConstructor
+                ?.parameters
+                .orEmpty()
+                .none { it.name == "type" },
+            "Variant must not declare the discriminator property as a field",
         )
     }
 }


### PR DESCRIPTION
## Problem

In a sealed hierarchy (`oneOf`/`anyOf` + discriminator), each variant declares the discriminator as a single-value enum property (e.g. `type` with `enum: ["Circle"]`). The variant data class already omits that field — it is emitted via `@SerialName` / `@JsonClassDiscriminator` — but the inline enum was still being hoisted into an orphan generated type per variant (e.g. `Circle_Type`, `Square_Type`, ...), none of which is ever referenced. Dead code.

## Fix

`ApiSpec.stripDiscriminatorProperties()` removes the discriminator property from every variant schema up front in `generateWithResolvedSpec`, so inline-enum collection, resolution, and generation all stay consistent and no orphan `*_Type` enum is produced.

The `@SerialName` value comes from the parent's `discriminator.mapping` (`resolveSerialName`), so dropping the field is lossless. Non-discriminator inline enums on variants are unaffected.

## Tests

New test in `ModelGeneratorPolymorphicTest`: the discriminator enum is not hoisted, a genuine non-discriminator inline enum on the same variant still is, and the variant declares no discriminator field. `:core:test` and `ktlintCheck` are green.
