### PR TITLE
fix(core): map content-less response schema to Unit, not JsonElement

### DIFF
--- a/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
@@ -282,6 +282,7 @@ object SpecParser {
                                 schema = resp.content
                                     ?.get(ContentType.JSON_CONTENT_TYPE.value)
                                     ?.schema
+                                    ?.takeUnless { it.isEmptyContent }
                                     ?.toTypeRef("${operationId.replaceFirstChar { it.uppercase() }}Response"),
                             )
                         }
@@ -501,6 +502,22 @@ object SpecParser {
             this !in componentSchemaIdentity && type == "object" && !properties.isNullOrEmpty()
 
     private val Schema<*>.isEnumSchema get(): Boolean = !enum.isNullOrEmpty()
+
+    /**
+     * True when the schema carries no structure at all — no `type`, `$ref`, properties, items,
+     * combinators, enum, or additionalProperties (e.g. `{}` or `{ "nullable": true }`). As a
+     * response body this means "no content", which is generated as a `Unit` return type.
+     */
+    private val Schema<*>.isEmptyContent: Boolean
+        get() = `$ref` == null &&
+            type == null &&
+            properties.isNullOrEmpty() &&
+            allOf.isNullOrEmpty() &&
+            oneOf.isNullOrEmpty() &&
+            anyOf.isNullOrEmpty() &&
+            enum.isNullOrEmpty() &&
+            additionalProperties == null &&
+            items == null
 
     /**
      * Builds a [TypeRef.InlineEnum] for an enum schema that is not a named component

--- a/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserEmptyResponseTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserEmptyResponseTest.kt
@@ -1,0 +1,35 @@
+package com.avsystem.justworks.core.parser
+
+import com.avsystem.justworks.core.model.ApiSpec
+import com.avsystem.justworks.core.model.TypeRef
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+/**
+ * A response whose schema carries no content (`{}` / `{ "nullable": true }`) must parse to a
+ * `null` response schema, so the client generates a `Unit` return type instead of `JsonElement`.
+ * A response with a real `$ref` schema stays typed.
+ */
+class SpecParserEmptyResponseTest : SpecParserTestBase() {
+    private val spec: ApiSpec = parseSpec(loadResource("fixtures/empty-response-schema-spec.json"))
+
+    private fun responseSchema(operationId: String, code: String) = spec.endpoints
+        .first { it.operationId == operationId }
+        .responses
+        .getValue(code)
+        .schema
+
+    @Test
+    fun `empty content response schema parses to null`() {
+        assertNull(responseSchema("createThing", "201"))
+    }
+
+    @Test
+    fun `response with a ref schema stays typed`() {
+        val schema = responseSchema("getThing", "200")
+        assertIs<TypeRef.Reference>(schema)
+        assertEquals("Thing", schema.schemaName)
+    }
+}

--- a/core/src/test/resources/fixtures/empty-response-schema-spec.json
+++ b/core/src/test/resources/fixtures/empty-response-schema-spec.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.2",
+  "info": { "title": "empty-response", "version": "1.0" },
+  "paths": {
+    "/things": {
+      "post": {
+        "operationId": "createThing",
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": { "schema": { "nullable": true } }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "getThing",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Thing" } }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Thing": {
+        "type": "object",
+        "properties": { "id": { "type": "string" } },
+        "required": ["id"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

A response whose schema carries no structure — e.g. `{}` or `{ "nullable": true }` — means "no body". It was resolved to `TypeRef.Unknown` and surfaced in the client as an untyped `JsonElement` success type instead of `Unit`.

## Fix

Such a response schema now parses to a `null` schema, routing it through the existing no-content code path in `ClientGenerator.resolveReturnType`, which already falls back to `UNIT`. No runtime change is needed — the `Unit` path already existed for responses declared without `content`.

Responses with a real schema (`$ref`, `type`, properties, items, combinators, enum, or `additionalProperties`) are unaffected.

## Tests

New `SpecParserEmptyResponseTest` + fixture: an empty-content response schema parses to `null`, while a sibling response with a `$ref` schema stays typed. `:core:test` and `ktlintCheck` are green.
