### PR TITLE
feat(core): honor schema-level nullable:true in OpenAPI 3.0

### DIFF
--- a/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
@@ -395,19 +395,15 @@ object SpecParser {
         val topRequired = schema.required.orEmpty().toSet()
         val contextCreator: (String) -> String? = { propName -> "$parentName.${propName.toPascalCase()}" }
 
-        val (required, properties) = schema.allOf
-            .orEmpty()
-            .fold(topRequired to emptyMap<String, PropertyModel>()) { (accRequired, accProperties), subSchema ->
-                val resolvedSchema = subSchema.resolveSubSchema()
-                val mergedRequired = accRequired + resolvedSchema.required.orEmpty().toSet()
-                mergedRequired to accProperties + resolvedSchema.propertyModels(mergedRequired, contextCreator)
-            }
+        val subSchemas = schema.allOf.orEmpty().map { it.resolveSubSchema() }
 
-        val topLevelProperties = schema.propertyModels(required, contextCreator)
-        val finalProperties =
-            properties.plus(topLevelProperties).values.map { prop ->
-                prop.copy(nullable = prop.name !in required || prop.nullable)
-            }
+        val required = topRequired + subSchemas.flatMap { it.required.orEmpty() }.toSet()
+
+        val properties = subSchemas.fold(emptyMap<String, PropertyModel>()) { accProperties, resolvedSchema ->
+            accProperties + resolvedSchema.propertyModels(required, contextCreator)
+        }
+
+        val finalProperties = properties.plus(schema.propertyModels(required, contextCreator)).values.toList()
 
         return finalProperties to required
     }

--- a/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
@@ -396,7 +396,10 @@ object SpecParser {
 
         val topLevelProperties = schema.propertyModels(required, contextCreator)
         val finalProperties =
-            properties.plus(topLevelProperties).values.map { prop -> prop.copy(nullable = prop.name !in required) }
+            properties.plus(topLevelProperties).values.map { prop ->
+                // Recompute against the union of required sets, but keep schema-level `nullable: true`.
+                prop.copy(nullable = prop.name !in required || prop.nullable)
+            }
 
         return finalProperties to required
     }
@@ -507,7 +510,8 @@ object SpecParser {
                     name = propName,
                     type = propSchema.toTypeRef(createContext(propName)),
                     description = propSchema.description,
-                    nullable = propName !in required,
+                    // OpenAPI 3.0 `nullable: true` makes a property nullable independent of `required`.
+                    nullable = propName !in required || propSchema.nullable == true,
                     defaultValue = propSchema.default,
                 )
             }

--- a/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
@@ -397,7 +397,6 @@ object SpecParser {
         val topLevelProperties = schema.propertyModels(required, contextCreator)
         val finalProperties =
             properties.plus(topLevelProperties).values.map { prop ->
-                // Recompute against the union of required sets, but keep schema-level `nullable: true`.
                 prop.copy(nullable = prop.name !in required || prop.nullable)
             }
 
@@ -510,7 +509,6 @@ object SpecParser {
                     name = propName,
                     type = propSchema.toTypeRef(createContext(propName)),
                     description = propSchema.description,
-                    // OpenAPI 3.0 `nullable: true` makes a property nullable independent of `required`.
                     nullable = propName !in required || propSchema.nullable == true,
                     defaultValue = propSchema.default,
                 )

--- a/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserTest.kt
@@ -180,6 +180,43 @@ class SpecParserTest : SpecParserTestBase() {
     }
 
     @Test
+    fun `allOf property required in a later member is not nullable`() {
+        // `foo` is declared (optional) in the first allOf member and marked required in the
+        // second. After merging it is required, so it must be non-nullable — regardless of the
+        // order the members are listed. Regression test: nullability must be derived from the
+        // full merged `required` set, not one accumulated mid-fold.
+        val spec = parseSpec(
+            """
+            openapi: 3.0.0
+            info:
+              title: AllOf API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Base:
+                  type: object
+                  properties:
+                    foo:
+                      type: string
+                RequiresFoo:
+                  type: object
+                  required:
+                    - foo
+                Combined:
+                  allOf:
+                    - ${'$'}ref: '#/components/schemas/Base'
+                    - ${'$'}ref: '#/components/schemas/RequiresFoo'
+            """.trimIndent().toTempFile(),
+        )
+        val combined = spec.schemas.find { it.name == "Combined" } ?: fail("Combined not found")
+        val foo = combined.properties.first { it.name == "foo" }
+
+        assertTrue("foo" in combined.requiredProperties, "sanity: foo should be required after merge")
+        assertFalse(foo.nullable, "foo is required (via a later allOf member) and must be non-nullable")
+    }
+
+    @Test
     fun `parsed endpoints have tags`() {
         val listPets = petstore.endpoints.find { it.operationId == "listPets" }!!
 

--- a/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserTest.kt
@@ -13,6 +13,7 @@ import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -138,6 +139,44 @@ class SpecParserTest : SpecParserTestBase() {
 
         val bodyType = assertIs<TypeRef.Reference>(body.schema)
         assertEquals("NewPet", bodyType.schemaName)
+    }
+
+    @Test
+    fun `schema-level nullable controls property nullability independent of required`() {
+        val spec = parseSpec(
+            """
+            openapi: 3.0.0
+            info:
+              title: Nullable API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Thing:
+                  type: object
+                  required:
+                    - requiredNullable
+                    - requiredPlain
+                  properties:
+                    requiredNullable:
+                      type: string
+                      nullable: true
+                    requiredPlain:
+                      type: string
+                    optionalNullable:
+                      type: string
+                      nullable: true
+                    optionalPlain:
+                      type: string
+            """.trimIndent().toTempFile(),
+        )
+        val thing = spec.schemas.find { it.name == "Thing" } ?: fail("Thing not found")
+        val props = thing.properties.associateBy { it.name }
+
+        assertTrue(props.getValue("requiredNullable").nullable, "required + nullable:true should be nullable")
+        assertFalse(props.getValue("requiredPlain").nullable, "required without nullable should be non-nullable")
+        assertTrue(props.getValue("optionalNullable").nullable, "optional + nullable:true should be nullable")
+        assertTrue(props.getValue("optionalPlain").nullable, "optional should be nullable")
     }
 
     @Test


### PR DESCRIPTION
## What

OpenAPI 3.0 `nullable: true` was ignored — nullability came only from the parent's `required` set. A property that is `required` **and** `nullable: true` was generated as a non-nullable Kotlin type, which is incorrect.

- `SpecParser.propertyModels` now sets `nullable = propName !in required || propSchema.nullable == true`.
- The `allOf` merge preserves schema-level nullability when recomputing against the union of required sets (`prop.name !in required || prop.nullable`).

## Tests

Covers the four combinations on a plain object schema:
- required + `nullable:true` → nullable
- required + no nullable → non-nullable
- optional + `nullable:true` → nullable
- optional + no nullable → nullable

## Notes

OpenAPI 3.1 nullability (type arrays / `null` in `type`) is out of scope — this addresses the 3.0 `nullable` keyword. `allOf`+`nullable` ordering edge cases (a property declared in one member, marked required in a later member) are rare and handled best-effort via the OR.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)