### PR TITLE
feat(plugin): add generateKdoc configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ justworks {
             // Optional: override default sub-packages
             apiPackage = "com.example.payments.client"
             modelPackage = "com.example.payments.dto"
+            // Optional: suppress KDoc in generated code (default true)
+            generateKdoc = false
         }
     }
 }
@@ -56,6 +58,7 @@ extra configuration needed.
 | `packageName`  | Yes      | --                   | Base package for generated code        |
 | `apiPackage`   | No       | `$packageName.api`   | Package for API client classes         |
 | `modelPackage` | No       | `$packageName.model` | Package for model/data classes         |
+| `generateKdoc` | No       | `true`               | Emit KDoc comments in generated code   |
 
 ## Supported OpenAPI Features
 

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/CodeGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/CodeGenerator.kt
@@ -19,12 +19,14 @@ object CodeGenerator {
         modelPackage: String,
         apiPackage: String,
         outputDir: File,
+        generateKdoc: Boolean = true,
     ): Result {
         val hierarchy = Hierarchy(ModelPackage(modelPackage)).apply {
             addSchemas(spec.schemas)
         }
+        val options = OutputOptions(generateKdoc = generateKdoc)
 
-        val (modelFiles, resolvedSpec) = context(hierarchy, NameRegistry()) {
+        val (modelFiles, resolvedSpec) = context(hierarchy, options, NameRegistry()) {
             ModelGenerator.generateWithResolvedSpec(spec)
         }
 
@@ -32,7 +34,7 @@ object CodeGenerator {
 
         val hasPolymorphicTypes = modelFiles.any { it.name == SERIALIZERS_MODULE.simpleName }
 
-        val clientFiles = context(hierarchy, ApiPackage(apiPackage), NameRegistry()) {
+        val clientFiles = context(hierarchy, options, ApiPackage(apiPackage), NameRegistry()) {
             ClientGenerator.generate(resolvedSpec, hasPolymorphicTypes)
         }
 

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/OutputOptions.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/OutputOptions.kt
@@ -1,0 +1,9 @@
+package com.avsystem.justworks.core.gen
+
+/**
+ * Generation-time options that tune the produced code without affecting the
+ * parsed [com.avsystem.justworks.core.model.ApiSpec] or the schema [Hierarchy].
+ *
+ * Threaded through the generators as a context receiver.
+ */
+internal data class OutputOptions(val generateKdoc: Boolean = true,)

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/client/ClientGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/client/ClientGenerator.kt
@@ -17,6 +17,7 @@ import com.avsystem.justworks.core.gen.HTTP_SUCCESS
 import com.avsystem.justworks.core.gen.Hierarchy
 import com.avsystem.justworks.core.gen.JSON_ELEMENT
 import com.avsystem.justworks.core.gen.NameRegistry
+import com.avsystem.justworks.core.gen.OutputOptions
 import com.avsystem.justworks.core.gen.TOKEN
 import com.avsystem.justworks.core.gen.client.BodyGenerator.buildFunctionBody
 import com.avsystem.justworks.core.gen.client.ParametersGenerator.buildBodyParams
@@ -55,7 +56,7 @@ internal object ClientGenerator {
     private const val DEFAULT_TAG = "Default"
     private const val API_SUFFIX = "Api"
 
-    context(_: Hierarchy, _: ApiPackage, _: NameRegistry)
+    context(_: Hierarchy, _: OutputOptions, _: ApiPackage, _: NameRegistry)
     fun generate(spec: ApiSpec, hasPolymorphicTypes: Boolean): List<FileSpec> {
         val grouped = spec.endpoints.groupBy { it.tags.firstOrNull() ?: DEFAULT_TAG }
         return grouped.map { (tag, endpoints) ->
@@ -63,7 +64,7 @@ internal object ClientGenerator {
         }
     }
 
-    context(hierarchy: Hierarchy, apiPackage: ApiPackage, nameRegistry: NameRegistry)
+    context(hierarchy: Hierarchy, _: OutputOptions, apiPackage: ApiPackage, nameRegistry: NameRegistry)
     private fun generateClientFile(
         tag: String,
         endpoints: List<Endpoint>,
@@ -219,7 +220,7 @@ internal object ClientGenerator {
         return builder.build()
     }
 
-    context(_: Hierarchy, methodRegistry: NameRegistry)
+    context(_: Hierarchy, options: OutputOptions, methodRegistry: NameRegistry)
     private fun generateEndpointFunction(endpoint: Endpoint): FunSpec {
         val functionName = methodRegistry.register(endpoint.operationId.toCamelCase())
         val returnBodyType = resolveReturnType(endpoint)
@@ -251,23 +252,25 @@ internal object ClientGenerator {
             funBuilder.addParameters(buildBodyParams(endpoint.requestBody))
         }
 
-        val kdocParts = mutableListOf<String>()
-        endpoint.summary?.let { kdocParts.add(it) }
-        endpoint.description?.let {
-            if (kdocParts.isNotEmpty()) kdocParts.add("")
-            kdocParts.add(it)
-        }
-        val paramDocs = endpoint.parameters.filter { it.description != null }
-        if (paramDocs.isNotEmpty() && kdocParts.isNotEmpty()) kdocParts.add("")
-        paramDocs.forEach { param ->
-            kdocParts.add("@param ${param.name.toCamelCase()} ${param.description}")
-        }
-        if (kdocParts.isNotEmpty()) {
-            funBuilder.addKdoc("%L", kdocParts.joinToString("\n"))
-        }
-        if (returnBodyType != UNIT) {
-            if (kdocParts.isNotEmpty()) funBuilder.addKdoc("\n\n")
-            funBuilder.addKdoc("@return [%T] containing [%T] on success", HTTP_SUCCESS, returnBodyType)
+        if (options.generateKdoc) {
+            val kdocParts = mutableListOf<String>()
+            endpoint.summary?.let { kdocParts.add(it) }
+            endpoint.description?.let {
+                if (kdocParts.isNotEmpty()) kdocParts.add("")
+                kdocParts.add(it)
+            }
+            val paramDocs = endpoint.parameters.filter { it.description != null }
+            if (paramDocs.isNotEmpty() && kdocParts.isNotEmpty()) kdocParts.add("")
+            paramDocs.forEach { param ->
+                kdocParts.add("@param ${param.name.toCamelCase()} ${param.description}")
+            }
+            if (kdocParts.isNotEmpty()) {
+                funBuilder.addKdoc("%L", kdocParts.joinToString("\n"))
+            }
+            if (returnBodyType != UNIT) {
+                if (kdocParts.isNotEmpty()) funBuilder.addKdoc("\n\n")
+                funBuilder.addKdoc("@return [%T] containing [%T] on success", HTTP_SUCCESS, returnBodyType)
+            }
         }
 
         funBuilder.addCode(buildFunctionBody(endpoint, params, returnBodyType))

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -16,6 +16,7 @@ import com.avsystem.justworks.core.gen.K_SERIALIZER
 import com.avsystem.justworks.core.gen.LOCAL_DATE
 import com.avsystem.justworks.core.gen.NameRegistry
 import com.avsystem.justworks.core.gen.OPT_IN
+import com.avsystem.justworks.core.gen.OutputOptions
 import com.avsystem.justworks.core.gen.PRIMITIVE_KIND
 import com.avsystem.justworks.core.gen.PRIMITIVE_SERIAL_DESCRIPTOR_FUN
 import com.avsystem.justworks.core.gen.SERIALIZABLE
@@ -70,10 +71,10 @@ import kotlin.time.Instant
 internal object ModelGenerator {
     data class GenerateResult(val files: List<FileSpec>, val resolvedSpec: ApiSpec)
 
-    context(_: Hierarchy, _: NameRegistry)
+    context(_: Hierarchy, _: OutputOptions, _: NameRegistry)
     fun generate(spec: ApiSpec): List<FileSpec> = generateWithResolvedSpec(spec).files
 
-    context(hierarchy: Hierarchy, nameRegistry: NameRegistry)
+    context(hierarchy: Hierarchy, _: OutputOptions, nameRegistry: NameRegistry)
     fun generateWithResolvedSpec(spec: ApiSpec): GenerateResult {
         ensureReserved(spec, nameRegistry)
         val (inlineSchemas, nameMap) = collectAllInlineSchemas(spec)
@@ -162,7 +163,7 @@ internal object ModelGenerator {
         return schemas to nameMap
     }
 
-    context(hierarchy: Hierarchy)
+    context(hierarchy: Hierarchy, _: OutputOptions)
     private fun generateSchemaFiles(schema: SchemaModel): List<FileSpec> = when {
         !schema.anyOf.isNullOrEmpty() || !schema.oneOf.isNullOrEmpty() -> {
             if (schema.name in hierarchy.anyOfWithoutDiscriminator) {
@@ -188,7 +189,7 @@ internal object ModelGenerator {
     /**
      * Generates a sealed interface with nested subtypes for oneOf or anyOf-with-discriminator schemas.
      */
-    context(hierarchy: Hierarchy)
+    context(hierarchy: Hierarchy, options: OutputOptions)
     private fun generateSealedHierarchy(schema: SchemaModel): FileSpec {
         val className = ClassName(hierarchy.modelPackage, schema.name)
 
@@ -204,7 +205,7 @@ internal object ModelGenerator {
             )
         }
 
-        if (schema.description != null) {
+        if (options.generateKdoc && schema.description != null) {
             parentBuilder.addKdoc("%L", schema.description)
         }
 
@@ -239,7 +240,7 @@ internal object ModelGenerator {
      * Builds a nested TypeSpec for a variant inside a sealed interface hierarchy.
      * Generates an `object` when there are no properties, or a `data class` otherwise.
      */
-    context(hierarchy: Hierarchy)
+    context(hierarchy: Hierarchy, _: OutputOptions)
     private fun buildNestedVariant(
         variantSchema: SchemaModel?,
         variantName: String,
@@ -281,7 +282,7 @@ internal object ModelGenerator {
      * Builds primary constructor and data class properties from a schema's property list.
      * Shared by [generateDataClass] and [buildNestedVariant].
      */
-    context(_: Hierarchy)
+    context(hierarchy: Hierarchy, options: OutputOptions)
     private fun buildConstructorAndProperties(schema: SchemaModel, builder: TypeSpec.Builder) {
         val sortedProps = schema.properties.sortedBy { prop ->
             when {
@@ -307,14 +308,14 @@ internal object ModelGenerator {
                 .builder(kotlinName, type)
                 .initializer(kotlinName)
                 .addAnnotation(AnnotationSpec.builder(SERIAL_NAME).addMember("%S", prop.name).build())
-                .apply { prop.description?.let { addKdoc("%L", it) } }
+                .apply { if (options.generateKdoc) prop.description?.let { addKdoc("%L", it) } }
                 .build()
         }
 
         builder.primaryConstructor(constructorBuilder.build())
         builder.addProperties(propertySpecs)
 
-        if (schema.description != null) {
+        if (options.generateKdoc && schema.description != null) {
             builder.addKdoc("%L", schema.description)
         }
     }
@@ -323,7 +324,7 @@ internal object ModelGenerator {
      * Generates a sealed interface for anyOf without discriminator schemas.
      * Only used for the JsonContentPolymorphicSerializer pattern.
      */
-    context(hierarchy: Hierarchy)
+    context(hierarchy: Hierarchy, options: OutputOptions)
     private fun generateSealedInterface(schema: SchemaModel): FileSpec {
         val className = ClassName(hierarchy.modelPackage, schema.name)
 
@@ -337,7 +338,7 @@ internal object ModelGenerator {
                 .build(),
         )
 
-        if (schema.description != null) {
+        if (options.generateKdoc && schema.description != null) {
             typeSpec.addKdoc("%L", schema.description)
         }
 
@@ -347,7 +348,7 @@ internal object ModelGenerator {
     /**
      * Generates a JsonContentPolymorphicSerializer object for an anyOf schema without discriminator.
      */
-    context(hierarchy: Hierarchy)
+    context(hierarchy: Hierarchy, _: OutputOptions)
     private fun generatePolymorphicSerializer(schema: SchemaModel): FileSpec {
         val sealedClassName = ClassName(hierarchy.modelPackage, schema.name)
         val serializerClassName = ClassName(hierarchy.modelPackage, "${schema.name}Serializer")
@@ -405,7 +406,7 @@ internal object ModelGenerator {
     /**
      * Builds the body code for selectDeserializer using field-presence heuristics.
      */
-    context(hierarchy: Hierarchy)
+    context(hierarchy: Hierarchy, _: OutputOptions)
     private fun buildSelectDeserializerBody(
         parentName: String,
         uniqueFieldsPerVariant: Map<String, String?>,
@@ -449,7 +450,7 @@ internal object ModelGenerator {
      * Generates a data class FileSpec, with superinterfaces and @SerialName resolved from hierarchy.
      * Used for: standalone schemas, allOf composed classes, and anyOf-without-discriminator variants.
      */
-    context(hierarchy: Hierarchy)
+    context(hierarchy: Hierarchy, _: OutputOptions)
     private fun generateDataClass(schema: SchemaModel): FileSpec {
         val className = ClassName(hierarchy.modelPackage, schema.name)
 
@@ -502,7 +503,7 @@ internal object ModelGenerator {
      * Formats a default value from a PropertyModel for use in KotlinPoet ParameterSpec.defaultValue().
      */
 
-    context(hierarchy: Hierarchy)
+    context(hierarchy: Hierarchy, _: OutputOptions)
     private fun formatDefaultValue(prop: PropertyModel): CodeBlock = when (prop.type) {
         is TypeRef.Primitive -> {
             when (prop.type.type) {
@@ -549,7 +550,7 @@ internal object ModelGenerator {
         }
     }
 
-    context(hierarchy: Hierarchy)
+    context(hierarchy: Hierarchy, options: OutputOptions)
     private fun generateEnumClass(enum: EnumModel): FileSpec {
         val className = ClassName(hierarchy.modelPackage, enum.name)
 
@@ -564,12 +565,12 @@ internal object ModelGenerator {
                         .builder(SERIAL_NAME)
                         .addMember("%S", value.name)
                         .build(),
-                ).apply { value.description?.let { addKdoc("%L", it) } }
+                ).apply { if (options.generateKdoc) value.description?.let { addKdoc("%L", it) } }
                 .build()
             typeSpec.addEnumConstant(enumRegistry.register(value.name.toEnumConstantName()), anonymousClass)
         }
 
-        if (enum.description != null) {
+        if (options.generateKdoc && enum.description != null) {
             typeSpec.addKdoc("%L", enum.description)
         }
 
@@ -674,13 +675,13 @@ internal object ModelGenerator {
             .build()
     }
 
-    context(hierarchy: Hierarchy)
+    context(hierarchy: Hierarchy, options: OutputOptions)
     private fun generateTypeAlias(schema: SchemaModel, primitiveType: TypeName): FileSpec {
         val className = ClassName(hierarchy.modelPackage, schema.name)
 
         val typeAlias = TypeAliasSpec.builder(schema.name, primitiveType)
 
-        if (schema.description != null) {
+        if (options.generateKdoc && schema.description != null) {
             typeAlias.addKdoc("%L", schema.description)
         }
 

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ClientGeneratorTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ClientGeneratorTest.kt
@@ -29,10 +29,15 @@ class ClientGeneratorTest {
     private val apiPackage = "com.example.api"
     private val modelPackage = "com.example.model"
 
-    private fun generate(spec: ApiSpec, hasPolymorphicTypes: Boolean = false): List<FileSpec> = context(
+    private fun generate(
+        spec: ApiSpec,
+        hasPolymorphicTypes: Boolean = false,
+        generateKdoc: Boolean = true,
+    ): List<FileSpec> = context(
         Hierarchy(ModelPackage(modelPackage)).apply {
             addSchemas(spec.schemas)
         },
+        OutputOptions(generateKdoc = generateKdoc),
         ApiPackage(apiPackage),
         NameRegistry(),
     ) {
@@ -114,6 +119,30 @@ class ClientGeneratorTest {
         val cls = clientClass(endpoint())
         val funSpec = cls.funSpecs.first { it.name == "listPets" }
         assertTrue(KModifier.SUSPEND in funSpec.modifiers, "Expected SUSPEND modifier")
+    }
+
+    // -- generateKdoc flag --
+
+    @Test
+    fun `generateKdoc false suppresses function KDoc`() {
+        val ep = endpoint(operationId = "listPets", summary = "List all pets")
+        val withKdoc = generate(spec(ep))
+            .first()
+            .members
+            .filterIsInstance<TypeSpec>()
+            .first()
+            .funSpecs
+            .first { it.name == "listPets" }
+        assertTrue(withKdoc.kdoc.toString().contains("List all pets"), "Expected KDoc by default")
+
+        val noKdoc = generate(spec(ep), generateKdoc = false)
+            .first()
+            .members
+            .filterIsInstance<TypeSpec>()
+            .first()
+            .funSpecs
+            .first { it.name == "listPets" }
+        assertTrue(noKdoc.kdoc.toString().isEmpty(), "Expected no KDoc when generateKdoc=false")
     }
 
     // -- CLNT-03: All HTTP methods --

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/IntegrationTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/IntegrationTest.kt
@@ -40,20 +40,27 @@ class IntegrationTest {
         }
     }
 
-    private fun generateModel(spec: ApiSpec): List<FileSpec> =
-        context(Hierarchy(ModelPackage(modelPackage)).apply { addSchemas(spec.schemas) }, NameRegistry()) {
-            ModelGenerator.generate(spec)
-        }
+    private fun generateModel(spec: ApiSpec): List<FileSpec> = context(
+        Hierarchy(ModelPackage(modelPackage)).apply { addSchemas(spec.schemas) },
+        OutputOptions(),
+        NameRegistry(),
+    ) {
+        ModelGenerator.generate(spec)
+    }
 
-    private fun generateModelWithResolvedSpec(spec: ApiSpec): ModelGenerator.GenerateResult =
-        context(Hierarchy(ModelPackage(modelPackage)).apply { addSchemas(spec.schemas) }, NameRegistry()) {
-            ModelGenerator.generateWithResolvedSpec(spec)
-        }
+    private fun generateModelWithResolvedSpec(spec: ApiSpec): ModelGenerator.GenerateResult = context(
+        Hierarchy(ModelPackage(modelPackage)).apply { addSchemas(spec.schemas) },
+        OutputOptions(),
+        NameRegistry(),
+    ) {
+        ModelGenerator.generateWithResolvedSpec(spec)
+    }
 
     private fun generateClient(spec: ApiSpec, hasPolymorphicTypes: Boolean = false): List<FileSpec> = context(
         Hierarchy(ModelPackage(modelPackage)).apply {
             addSchemas(spec.schemas)
         },
+        OutputOptions(),
         ApiPackage(apiPackage),
         NameRegistry(),
     ) {

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorPolymorphicTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorPolymorphicTest.kt
@@ -24,6 +24,7 @@ class ModelGeneratorPolymorphicTest {
         Hierarchy(ModelPackage(modelPackage)).apply {
             addSchemas(spec.schemas)
         },
+        OutputOptions(),
         NameRegistry(),
     ) {
         ModelGenerator.generate(spec)

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorRegressionTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorRegressionTest.kt
@@ -15,6 +15,7 @@ class ModelGeneratorRegressionTest {
         Hierarchy(ModelPackage(modelPackage)).apply {
             addSchemas(spec.schemas)
         },
+        OutputOptions(),
         NameRegistry(),
     ) {
         ModelGenerator.generate(spec)

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorTest.kt
@@ -23,10 +23,11 @@ import kotlin.test.assertTrue
 class ModelGeneratorTest {
     private val modelPackage = "com.example.model"
 
-    private fun generate(spec: ApiSpec) = context(
+    private fun generate(spec: ApiSpec, generateKdoc: Boolean = true) = context(
         Hierarchy(ModelPackage(modelPackage)).apply {
             addSchemas(spec.schemas)
         },
+        OutputOptions(generateKdoc = generateKdoc),
         NameRegistry(),
     ) {
         ModelGenerator.generate(spec)
@@ -144,6 +145,13 @@ class ModelGeneratorTest {
         val files = generate(spec(schemas = listOf(petSchema)))
         val typeSpec = files[0].members.filterIsInstance<TypeSpec>()[0]
         assertTrue(typeSpec.kdoc.toString().contains("A pet in the store"), "Expected KDoc from description")
+    }
+
+    @Test
+    fun `generateKdoc false suppresses schema KDoc`() {
+        val files = generate(spec(schemas = listOf(petSchema)), generateKdoc = false)
+        val typeSpec = files[0].members.filterIsInstance<TypeSpec>()[0]
+        assertTrue(typeSpec.kdoc.toString().isEmpty(), "Expected no KDoc when generateKdoc=false")
     }
 
     @Test

--- a/plugin/src/functionalTest/kotlin/com/avsystem/justworks/gradle/JustworksPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/avsystem/justworks/gradle/JustworksPluginFunctionalTest.kt
@@ -61,6 +61,7 @@ class JustworksPluginFunctionalTest {
               schemas:
                 Pet:
                   type: object
+                  description: A pet in the store
                   required:
                     - id
                     - name
@@ -189,6 +190,30 @@ class JustworksPluginFunctionalTest {
         val content = clientFile.readText()
         assertTrue(content.contains("suspend fun"), "PetsApi should contain suspend functions")
         assertTrue(content.contains("class PetsApi"), "PetsApi should define PetsApi class")
+    }
+
+    @Test
+    fun `generateKdoc true by default emits KDoc in generated code`() {
+        writeBuildFile()
+
+        runner("justworksGenerateMain").build()
+
+        val petFile = projectDir.resolve("build/generated/justworks/main/com/example/model/Pet.kt")
+        val clientFile = projectDir.resolve("build/generated/justworks/main/com/example/api/PetsApi.kt")
+        assertTrue(petFile.readText().contains("/**"), "Model should contain KDoc by default")
+        assertTrue(clientFile.readText().contains("/**"), "Client should contain KDoc by default")
+    }
+
+    @Test
+    fun `generateKdoc false suppresses all KDoc in generated code`() {
+        writeBuildFile("generateKdoc = false")
+
+        runner("justworksGenerateMain").build()
+
+        val petFile = projectDir.resolve("build/generated/justworks/main/com/example/model/Pet.kt")
+        val clientFile = projectDir.resolve("build/generated/justworks/main/com/example/api/PetsApi.kt")
+        assertFalse(petFile.readText().contains("/**"), "Model should contain no KDoc when generateKdoc=false")
+        assertFalse(clientFile.readText().contains("/**"), "Client should contain no KDoc when generateKdoc=false")
     }
 
     @Test

--- a/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksGenerateTask.kt
+++ b/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksGenerateTask.kt
@@ -38,6 +38,10 @@ abstract class JustworksGenerateTask : DefaultTask() {
     @get:Input
     abstract val modelPackage: Property<String>
 
+    /** Whether to emit KDoc comments in generated code. */
+    @get:Input
+    abstract val generateKdoc: Property<Boolean>
+
     /** Output directory for generated Kotlin source files. */
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
@@ -61,6 +65,7 @@ abstract class JustworksGenerateTask : DefaultTask() {
                     modelPackage = modelPackage.get(),
                     apiPackage = apiPackage.get(),
                     outputDir = outDir,
+                    generateKdoc = generateKdoc.get(),
                 )
 
                 logger.lifecycle(

--- a/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksPlugin.kt
+++ b/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksPlugin.kt
@@ -55,6 +55,7 @@ class JustworksPlugin : Plugin<Project> {
                     task.specFile.set(spec.specFile)
                     task.apiPackage.set(spec.apiPackage.orElse(spec.packageName.map { "$it.api" }))
                     task.modelPackage.set(spec.modelPackage.orElse(spec.packageName.map { "$it.model" }))
+                    task.generateKdoc.set(spec.generateKdoc.orElse(true))
                     task.outputDir.set(project.layout.buildDirectory.dir("generated/justworks/${spec.name}"))
                     task.group = "code generation"
                     task.description = "Generate Kotlin client from '${spec.name}' OpenAPI spec"

--- a/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksSpecConfiguration.kt
+++ b/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksSpecConfiguration.kt
@@ -47,5 +47,11 @@ abstract class JustworksSpecConfiguration
          */
         abstract val modelPackage: Property<String>
 
+        /**
+         * Whether to emit KDoc comments in generated code.
+         * Defaults to `true`. Set to `false` to reduce generated file size and noise.
+         */
+        abstract val generateKdoc: Property<Boolean>
+
         override fun getName(): String = name
     }


### PR DESCRIPTION
## What

Adds a `generateKdoc` (Boolean, default `true`) option to `JustworksSpecConfiguration`. When set to `false`, generated client and model code contains no KDoc comments — useful for reducing generated file size and noise.

## Flow

`generateKdoc` DSL property → `JustworksGenerateTask` (`@Input`) → `CodeGenerator.generate(..., generateKdoc)` → `Hierarchy.generateKdoc`. Every `addKdoc` call in `ModelGenerator` (data classes, sealed hierarchies/interfaces, properties, enums + constants, typealiases) and `ClientGenerator` (endpoint functions) is gated behind the flag.

Default `true` → no breaking change.

## Tests

- Core: `ModelGenerator` and `ClientGenerator` suppress KDoc when `generateKdoc = false`, emit it by default.
- Plugin functional: end-to-end, asserts generated `Pet.kt` / `PetsApi.kt` contain `/**` by default and none when `generateKdoc = false`.

## Docs

README config table row + usage example.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
