### PR TITLE
feat(plugin): add apiClassPrefix / apiClassSuffix options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ extra configuration needed.
 |----------------|----------|----------------------|----------------------------------------|
 | `specFile`     | Yes      | --                   | Path to the OpenAPI spec (.yaml/.json) |
 | `packageName`  | Yes      | --                   | Base package for generated code        |
-| `apiPackage`   | No       | `$packageName.api`   | Package for API client classes         |
-| `modelPackage` | No       | `$packageName.model` | Package for model/data classes         |
-| `generateKdoc` | No       | `true`               | Emit KDoc comments in generated code   |
+| `apiPackage`     | No     | `$packageName.api`   | Package for API client classes         |
+| `modelPackage`   | No     | `$packageName.model` | Package for model/data classes         |
+| `generateKdoc`   | No     | `true`               | Emit KDoc comments in generated code   |
+| `apiClassPrefix` | No     | `""`                 | Prefix for generated API client class names |
+| `apiClassSuffix` | No     | `"Api"`              | Suffix for generated API client class names |
 
 ## Supported OpenAPI Features
 
@@ -212,6 +214,23 @@ justworks {
             packageName = "com.example.petstore"
             apiPackage = "com.example.petstore.client"   // default: packageName.api
             modelPackage = "com.example.petstore.dto"     // default: packageName.model
+        }
+    }
+}
+```
+
+### API Client Class Names
+
+Generated client class names default to `<Tag>Api` (e.g. tag `pets` -> `PetsApi`). Customize with a prefix and/or suffix:
+
+```kotlin
+justworks {
+    specs {
+        register("petstore") {
+            specFile = file("api/petstore.yaml")
+            packageName = "com.example.petstore"
+            apiClassPrefix = "My"        // default: ""
+            apiClassSuffix = "Client"    // default: "Api"  ->  tag `pets` -> MyPetsClient
         }
     }
 }

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/CodeGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/CodeGenerator.kt
@@ -19,12 +19,11 @@ object CodeGenerator {
         modelPackage: String,
         apiPackage: String,
         outputDir: File,
-        generateKdoc: Boolean = true,
+        options: OutputOptions = OutputOptions(),
     ): Result {
         val hierarchy = Hierarchy(ModelPackage(modelPackage)).apply {
             addSchemas(spec.schemas)
         }
-        val options = OutputOptions(generateKdoc = generateKdoc)
 
         val (modelFiles, resolvedSpec) = context(hierarchy, options, NameRegistry()) {
             ModelGenerator.generateWithResolvedSpec(spec)

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/OutputOptions.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/OutputOptions.kt
@@ -6,4 +6,8 @@ package com.avsystem.justworks.core.gen
  *
  * Threaded through the generators as a context receiver.
  */
-internal data class OutputOptions(val generateKdoc: Boolean = true,)
+data class OutputOptions(
+    val generateKdoc: Boolean = true,
+    val apiClassPrefix: String = "",
+    val apiClassSuffix: String = "Api",
+)

--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/client/ClientGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/client/ClientGenerator.kt
@@ -54,7 +54,6 @@ import com.squareup.kotlinpoet.UNIT
 
 internal object ClientGenerator {
     private const val DEFAULT_TAG = "Default"
-    private const val API_SUFFIX = "Api"
 
     context(_: Hierarchy, _: OutputOptions, _: ApiPackage, _: NameRegistry)
     fun generate(spec: ApiSpec, hasPolymorphicTypes: Boolean): List<FileSpec> {
@@ -64,7 +63,7 @@ internal object ClientGenerator {
         }
     }
 
-    context(hierarchy: Hierarchy, _: OutputOptions, apiPackage: ApiPackage, nameRegistry: NameRegistry)
+    context(hierarchy: Hierarchy, options: OutputOptions, apiPackage: ApiPackage, nameRegistry: NameRegistry)
     private fun generateClientFile(
         tag: String,
         endpoints: List<Endpoint>,
@@ -72,7 +71,8 @@ internal object ClientGenerator {
         securitySchemes: List<SecurityScheme>,
         specTitle: String,
     ): FileSpec {
-        val className = ClassName(apiPackage, nameRegistry.register("${tag.toPascalCase()}$API_SUFFIX"))
+        val simpleName = "${options.apiClassPrefix}${tag.toPascalCase()}${options.apiClassSuffix}"
+        val className = ClassName(apiPackage, nameRegistry.register(simpleName))
 
         val clientInitializer = if (hasPolymorphicTypes) {
             val generatedSerializersModule = MemberName(hierarchy.modelPackage, GENERATED_SERIALIZERS_MODULE)

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ClientGeneratorTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ClientGeneratorTest.kt
@@ -32,12 +32,12 @@ class ClientGeneratorTest {
     private fun generate(
         spec: ApiSpec,
         hasPolymorphicTypes: Boolean = false,
-        generateKdoc: Boolean = true,
+        options: OutputOptions = OutputOptions(),
     ): List<FileSpec> = context(
         Hierarchy(ModelPackage(modelPackage)).apply {
             addSchemas(spec.schemas)
         },
-        OutputOptions(generateKdoc = generateKdoc),
+        options,
         ApiPackage(apiPackage),
         NameRegistry(),
     ) {
@@ -112,6 +112,39 @@ class ClientGeneratorTest {
         assertEquals(listOf("PetsApi", "StoreApi"), classNames)
     }
 
+    // -- API class prefix / suffix --
+
+    private fun clientClassName(options: OutputOptions): String =
+        generate(spec(endpoint(tags = listOf("Pets"))), options = options)
+            .first()
+            .members
+            .filterIsInstance<TypeSpec>()
+            .first()
+            .name!!
+
+    @Test
+    fun `default api class name uses Api suffix`() {
+        assertEquals("PetsApi", clientClassName(OutputOptions()))
+    }
+
+    @Test
+    fun `custom api class suffix is applied`() {
+        assertEquals("PetsClient", clientClassName(OutputOptions(apiClassSuffix = "Client")))
+    }
+
+    @Test
+    fun `custom api class prefix is applied`() {
+        assertEquals("MyPetsApi", clientClassName(OutputOptions(apiClassPrefix = "My")))
+    }
+
+    @Test
+    fun `custom api class prefix and suffix combined`() {
+        assertEquals(
+            "MyPetsClient",
+            clientClassName(OutputOptions(apiClassPrefix = "My", apiClassSuffix = "Client")),
+        )
+    }
+
     // -- CLNT-02: Endpoint functions are suspend --
 
     @Test
@@ -135,7 +168,7 @@ class ClientGeneratorTest {
             .first { it.name == "listPets" }
         assertTrue(withKdoc.kdoc.toString().contains("List all pets"), "Expected KDoc by default")
 
-        val noKdoc = generate(spec(ep), generateKdoc = false)
+        val noKdoc = generate(spec(ep), options = OutputOptions(generateKdoc = false))
             .first()
             .members
             .filterIsInstance<TypeSpec>()

--- a/plugin/src/functionalTest/kotlin/com/avsystem/justworks/gradle/JustworksPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/avsystem/justworks/gradle/JustworksPluginFunctionalTest.kt
@@ -193,6 +193,23 @@ class JustworksPluginFunctionalTest {
     }
 
     @Test
+    fun `custom apiClassPrefix and apiClassSuffix change generated client class name`() {
+        writeBuildFile(
+            """
+            apiClassPrefix = "My"
+            apiClassSuffix = "Client"
+            """.trimIndent(),
+        )
+
+        runner("justworksGenerateMain").build()
+
+        val apiDir = projectDir.resolve("build/generated/justworks/main/com/example/api")
+        val clientFile = apiDir.resolve("MyPetsClient.kt")
+        assertTrue(clientFile.exists(), "Expected MyPetsClient.kt; files: ${apiDir.listFiles()?.map { it.name }}")
+        assertTrue(clientFile.readText().contains("class MyPetsClient"), "Expected class MyPetsClient")
+    }
+
+    @Test
     fun `generateKdoc true by default emits KDoc in generated code`() {
         writeBuildFile()
 

--- a/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksGenerateTask.kt
+++ b/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksGenerateTask.kt
@@ -1,6 +1,7 @@
 package com.avsystem.justworks.gradle
 
 import com.avsystem.justworks.core.gen.CodeGenerator
+import com.avsystem.justworks.core.gen.OutputOptions
 import com.avsystem.justworks.core.parser.ParseResult
 import com.avsystem.justworks.core.parser.SpecParser
 import org.gradle.api.DefaultTask
@@ -42,6 +43,14 @@ abstract class JustworksGenerateTask : DefaultTask() {
     @get:Input
     abstract val generateKdoc: Property<Boolean>
 
+    /** Prefix for generated API client class names. */
+    @get:Input
+    abstract val apiClassPrefix: Property<String>
+
+    /** Suffix for generated API client class names. */
+    @get:Input
+    abstract val apiClassSuffix: Property<String>
+
     /** Output directory for generated Kotlin source files. */
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
@@ -65,7 +74,11 @@ abstract class JustworksGenerateTask : DefaultTask() {
                     modelPackage = modelPackage.get(),
                     apiPackage = apiPackage.get(),
                     outputDir = outDir,
-                    generateKdoc = generateKdoc.get(),
+                    options = OutputOptions(
+                        generateKdoc = generateKdoc.get(),
+                        apiClassPrefix = apiClassPrefix.get(),
+                        apiClassSuffix = apiClassSuffix.get(),
+                    ),
                 )
 
                 logger.lifecycle(

--- a/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksPlugin.kt
+++ b/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksPlugin.kt
@@ -56,6 +56,8 @@ class JustworksPlugin : Plugin<Project> {
                     task.apiPackage.set(spec.apiPackage.orElse(spec.packageName.map { "$it.api" }))
                     task.modelPackage.set(spec.modelPackage.orElse(spec.packageName.map { "$it.model" }))
                     task.generateKdoc.set(spec.generateKdoc.orElse(true))
+                    task.apiClassPrefix.set(spec.apiClassPrefix.orElse(""))
+                    task.apiClassSuffix.set(spec.apiClassSuffix.orElse("Api"))
                     task.outputDir.set(project.layout.buildDirectory.dir("generated/justworks/${spec.name}"))
                     task.group = "code generation"
                     task.description = "Generate Kotlin client from '${spec.name}' OpenAPI spec"

--- a/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksSpecConfiguration.kt
+++ b/plugin/src/main/kotlin/com/avsystem/justworks/gradle/JustworksSpecConfiguration.kt
@@ -53,5 +53,16 @@ abstract class JustworksSpecConfiguration
          */
         abstract val generateKdoc: Property<Boolean>
 
+        /**
+         * Prefix for generated API client class names. Defaults to `""`.
+         */
+        abstract val apiClassPrefix: Property<String>
+
+        /**
+         * Suffix for generated API client class names. Defaults to `"Api"`
+         * (e.g. tag `pets` -> `PetsApi`).
+         */
+        abstract val apiClassSuffix: Property<String>
+
         override fun getName(): String = name
     }


### PR DESCRIPTION
> **Stacked on #84** (`feat/42-generate-kdoc`). Base is `feat/42-generate-kdoc`, not `master`, so this diff shows only the #43 changes. Merge after #84.

## What

Adds `apiClassPrefix` (default `""`) and `apiClassSuffix` (default `"Api"`) to `JustworksSpecConfiguration`. Generated client class names become `<prefix><Tag><suffix>` — e.g. tag `pets` with prefix `My`, suffix `Client` → `MyPetsClient`. Previously `"Api"` was hardcoded in `ClientGenerator`.

## Refactor

`CodeGenerator.generate` now takes a single `OutputOptions` argument (made `public`) instead of loose `generateKdoc`/prefix/suffix flags. The plugin task builds `OutputOptions` from its inputs. Keeps the core entrypoint stable as more options are added.

## Tests

- Core `ClientGeneratorTest`: default `Api`, custom suffix, custom prefix, both combined.
- Plugin functional: `apiClassPrefix = "My"` + `apiClassSuffix = "Client"` produces `MyPetsClient.kt` with `class MyPetsClient`.

## Docs

README config table rows + a customization example.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
