### PR TITLE
fix: emit Set defaults for unique arrays in generated models

### DIFF
--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -549,10 +549,11 @@ internal object ModelGenerator {
         is TypeRef.Array -> {
             val elements = (value as? List<*>).orEmpty()
             if (elements.isEmpty()) {
-                CodeBlock.of("emptyList()")
+                CodeBlock.of(if (type.unique) "emptySet()" else "emptyList()")
             } else {
                 val items = elements.map { formatDefaultValue(type.items, it, propName) }
-                CodeBlock.of("listOf(%L)", items.joinToCode(separator = ", "))
+                val factory = if (type.unique) "setOf" else "listOf"
+                CodeBlock.of("$factory(%L)", items.joinToCode(separator = ", "))
             }
         }
 

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorTest.kt
@@ -698,6 +698,64 @@ class ModelGeneratorTest {
     }
 
     @Test
+    fun `unique array property with default emits setOf with element literals`() {
+        val schema =
+            SchemaModel(
+                name = "Config",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "tags",
+                            TypeRef.Array(TypeRef.Primitive(PrimitiveType.STRING), unique = true),
+                            null,
+                            false,
+                            listOf("X", "Y"),
+                        ),
+                    ),
+                requiredProperties = setOf("tags"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(schema)))
+        val typeSpec = files[0].members.filterIsInstance<TypeSpec>()[0]
+        val constructor = assertNotNull(typeSpec.primaryConstructor)
+        val param = constructor.parameters.first { it.name == "tags" }
+        assertEquals("setOf(\"X\", \"Y\")", param.defaultValue.toString())
+    }
+
+    @Test
+    fun `unique array property with empty default emits emptySet`() {
+        val schema =
+            SchemaModel(
+                name = "Config",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "tags",
+                            TypeRef.Array(TypeRef.Primitive(PrimitiveType.STRING), unique = true),
+                            null,
+                            false,
+                            emptyList<String>(),
+                        ),
+                    ),
+                requiredProperties = setOf("tags"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(schema)))
+        val typeSpec = files[0].members.filterIsInstance<TypeSpec>()[0]
+        val constructor = assertNotNull(typeSpec.primaryConstructor)
+        val param = constructor.parameters.first { it.name == "tags" }
+        assertEquals("emptySet()", param.defaultValue.toString())
+    }
+
+    @Test
     fun `long default generates default parameter with literal`() {
         val schema =
             SchemaModel(


### PR DESCRIPTION
## Problem

Generated code did not compile when a property was a unique array (`uniqueItems: true`). The type rendered as `Set<T>` but the default value was emitted as `emptyList()`/`listOf(...)`:

```kotlin
val directGroups: Set<String> = emptyList()  // does not compile
```

## Fix

`formatDefaultValue` Array branch ignored `TypeRef.Array.unique`. Now honors it:
- empty default → `emptySet()`
- non-empty default → `setOf(...)`

## Tests

Added two tests covering unique-array defaults (empty + with elements). Lint + tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)