### PR TITLE
fix: generate compilable defaults for object-reference properties

### DIFF
--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -542,8 +542,37 @@ internal object ModelGenerator {
         }
 
         is TypeRef.Reference -> {
-            val constantName = value.toString().toEnumConstantName()
-            CodeBlock.of("%T.%L", ClassName(hierarchy.modelPackage, type.schemaName), constantName)
+            val className = hierarchy[type.schemaName]
+            when (value) {
+                is Map<*, *> -> {
+                    val schema = hierarchy.schemasById[type.schemaName]
+                        ?: throw IllegalArgumentException(
+                            "Cannot build object default for property $propName: unknown schema '${type.schemaName}'",
+                        )
+
+                    val args = schema.properties
+                        .asSequence()
+                        .filter { it.name in value }
+                        .map { prop ->
+                            val valueCode = when (val rawValue = value[prop.name]) {
+                                null -> CodeBlock.of("null")
+                                else -> formatDefaultValue(prop.type, rawValue, prop.name)
+                            }
+                            CodeBlock.of("%N = %L", prop.name.toCamelCase(), valueCode)
+                        }.toList()
+                    CodeBlock.of("%T(%L)", className, args.joinToCode(separator = ", "))
+                }
+
+                is String -> {
+                    CodeBlock.of("%T.%L", className, value.toEnumConstantName())
+                }
+
+                else -> {
+                    error(
+                        "${value?.javaClass?.name} is not a valid default value for reference type $type (property $propName)",
+                    )
+                }
+            }
         }
 
         is TypeRef.Array -> {

--- a/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/parser/SpecParser.kt
@@ -17,7 +17,6 @@ import com.avsystem.justworks.core.accumulate
 import com.avsystem.justworks.core.accumulateAndReturnNull
 import com.avsystem.justworks.core.ensureNotNullOrAccumulate
 import com.avsystem.justworks.core.ensureOrAccumulate
-import com.avsystem.justworks.core.gen.properties
 import com.avsystem.justworks.core.model.ApiKeyLocation
 import com.avsystem.justworks.core.model.ApiSpec
 import com.avsystem.justworks.core.model.ContentType
@@ -38,6 +37,14 @@ import com.avsystem.justworks.core.model.TypeRef
 import com.avsystem.justworks.core.toEnumOrNull
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.BinaryNode
+import com.fasterxml.jackson.databind.node.BooleanNode
+import com.fasterxml.jackson.databind.node.MissingNode
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.NumericNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.POJONode
+import com.fasterxml.jackson.databind.node.TextNode
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.PathItem
@@ -47,7 +54,6 @@ import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.parser.core.models.ParseOptions
 import java.io.File
 import java.util.IdentityHashMap
-import kotlin.collections.emptyMap
 import io.swagger.v3.oas.models.parameters.Parameter as SwaggerParameter
 import io.swagger.v3.oas.models.security.SecurityScheme as SwaggerSecurityScheme
 
@@ -526,27 +532,19 @@ object SpecParser {
 
     /**
      * Normalizes a raw Swagger default into a plain Kotlin value the model layer can format
-     * without depending on Jackson. Array defaults arrive as a Jackson [ArrayNode]; unwrap them
-     * into a `List` of plain scalar values. Scalar defaults are already plain and pass through.
+     * without depending on Jackson. Jackson [JsonNode] defaults are unwrapped recursively into
+     * plain `List`/`Map`/scalar values; already-plain defaults pass through unchanged.
      */
     private fun normalizeDefault(default: Any?): Any? = when (default) {
         is ArrayNode -> default.map { normalizeDefault(it) }
-
-        is JsonNode -> when {
-            default.isShort -> default.shortValue()
-            default.isInt -> default.intValue()
-            default.isLong -> default.longValue()
-            default.isFloat -> default.floatValue()
-            default.isDouble -> default.doubleValue()
-            default.isBigDecimal -> default.decimalValue()
-            default.isBigInteger -> default.bigIntegerValue()
-            default.isNumber -> default.numberValue()
-            default.isBoolean -> default.booleanValue()
-            default.isNull -> null
-            default.isBinary -> default.binaryValue()
-            else -> default.asText()
-        }
-
+        is ObjectNode -> default.properties().associate { (k, v) -> k to normalizeDefault(v) }
+        is NullNode, is MissingNode -> null
+        is BooleanNode -> default.booleanValue()
+        is BinaryNode -> default.binaryValue()
+        is NumericNode -> default.numberValue()
+        is TextNode -> default.textValue()
+        is POJONode -> normalizeDefault(default.pojo)
+        is JsonNode -> default.asText()
         else -> default
     }
 

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorTest.kt
@@ -13,6 +13,7 @@ import com.avsystem.justworks.core.model.PropertyModel
 import com.avsystem.justworks.core.model.SchemaModel
 import com.avsystem.justworks.core.model.TypeRef
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeSpec
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -753,6 +754,550 @@ class ModelGeneratorTest {
         val constructor = assertNotNull(typeSpec.primaryConstructor)
         val param = constructor.parameters.first { it.name == "tags" }
         assertEquals("emptySet()", param.defaultValue.toString())
+    }
+
+    @Test
+    fun `reference property with object default constructs referenced class with named args`() {
+        val taskConfig =
+            SchemaModel(
+                name = "TaskConfig",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel("taskName", TypeRef.Primitive(PrimitiveType.STRING), null, true),
+                        PropertyModel(
+                            "parameters",
+                            TypeRef.Array(TypeRef.Primitive(PrimitiveType.STRING)),
+                            null,
+                            false,
+                        ),
+                        PropertyModel("isActive", TypeRef.Primitive(PrimitiveType.BOOLEAN), null, true),
+                    ),
+                requiredProperties = emptySet(),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val invocation =
+            SchemaModel(
+                name = "TaskTemplateInvocation",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "config",
+                            TypeRef.Reference("TaskConfig"),
+                            null,
+                            false,
+                            mapOf("taskName" to null, "parameters" to emptyList<String>(), "isActive" to null),
+                        ),
+                    ),
+                requiredProperties = setOf("config"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(taskConfig, invocation)))
+        val typeSpec =
+            files
+                .first { it.name == "TaskTemplateInvocation" }
+                .members
+                .filterIsInstance<TypeSpec>()[0]
+        val constructor = assertNotNull(typeSpec.primaryConstructor)
+        val param = constructor.parameters.first { it.name == "config" }
+        assertEquals(
+            "com.example.model.TaskConfig(taskName = null, parameters = emptyList(), isActive = null)",
+            param.defaultValue.toString(),
+        )
+    }
+
+    @Test
+    fun `object default formats overridden scalar values with correct literals`() {
+        val taskConfig =
+            SchemaModel(
+                name = "TaskConfig",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel("taskName", TypeRef.Primitive(PrimitiveType.STRING), null, true),
+                        PropertyModel("isActive", TypeRef.Primitive(PrimitiveType.BOOLEAN), null, true),
+                        PropertyModel("retries", TypeRef.Primitive(PrimitiveType.INT), null, true),
+                    ),
+                requiredProperties = emptySet(),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val invocation =
+            SchemaModel(
+                name = "TaskTemplateInvocation",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "config",
+                            TypeRef.Reference("TaskConfig"),
+                            null,
+                            false,
+                            mapOf("taskName" to "build", "isActive" to true, "retries" to 5),
+                        ),
+                    ),
+                requiredProperties = setOf("config"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(taskConfig, invocation)))
+        val param = files
+            .first { it.name == "TaskTemplateInvocation" }
+            .members
+            .filterIsInstance<TypeSpec>()[0]
+            .primaryConstructor!!
+            .parameters
+            .first { it.name == "config" }
+        assertEquals(
+            "com.example.model.TaskConfig(taskName = \"build\", isActive = true, retries = 5)",
+            param.defaultValue.toString(),
+        )
+    }
+
+    @Test
+    fun `object default with unique array property emits setOf`() {
+        val taskConfig =
+            SchemaModel(
+                name = "TaskConfig",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "labels",
+                            TypeRef.Array(TypeRef.Primitive(PrimitiveType.STRING), unique = true),
+                            null,
+                            false,
+                        ),
+                    ),
+                requiredProperties = setOf("labels"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val invocation =
+            SchemaModel(
+                name = "TaskTemplateInvocation",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "config",
+                            TypeRef.Reference("TaskConfig"),
+                            null,
+                            false,
+                            mapOf("labels" to listOf("a", "b")),
+                        ),
+                    ),
+                requiredProperties = setOf("config"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(taskConfig, invocation)))
+        val param = files
+            .first { it.name == "TaskTemplateInvocation" }
+            .members
+            .filterIsInstance<TypeSpec>()[0]
+            .primaryConstructor!!
+            .parameters
+            .first { it.name == "config" }
+        assertEquals(
+            "com.example.model.TaskConfig(labels = setOf(\"a\", \"b\"))",
+            param.defaultValue.toString(),
+        )
+    }
+
+    @Test
+    fun `object default skips keys that are not properties of the referenced schema`() {
+        val taskConfig =
+            SchemaModel(
+                name = "TaskConfig",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel("taskName", TypeRef.Primitive(PrimitiveType.STRING), null, true),
+                    ),
+                requiredProperties = emptySet(),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val invocation =
+            SchemaModel(
+                name = "TaskTemplateInvocation",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "config",
+                            TypeRef.Reference("TaskConfig"),
+                            null,
+                            false,
+                            mapOf("taskName" to "x", "unknownKey" to "ignored"),
+                        ),
+                    ),
+                requiredProperties = setOf("config"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(taskConfig, invocation)))
+        val param = files
+            .first { it.name == "TaskTemplateInvocation" }
+            .members
+            .filterIsInstance<TypeSpec>()[0]
+            .primaryConstructor!!
+            .parameters
+            .first { it.name == "config" }
+        assertEquals("com.example.model.TaskConfig(taskName = \"x\")", param.defaultValue.toString())
+    }
+
+    @Test
+    fun `nested object reference default constructs nested class`() {
+        val inner =
+            SchemaModel(
+                name = "Inner",
+                description = null,
+                properties =
+                    listOf(PropertyModel("content", TypeRef.Primitive(PrimitiveType.STRING), null, true)),
+                requiredProperties = emptySet(),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val outer =
+            SchemaModel(
+                name = "Outer",
+                description = null,
+                properties =
+                    listOf(PropertyModel("child", TypeRef.Reference("Inner"), null, true)),
+                requiredProperties = emptySet(),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val holder =
+            SchemaModel(
+                name = "Holder",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "outer",
+                            TypeRef.Reference("Outer"),
+                            null,
+                            false,
+                            mapOf("child" to mapOf("content" to "deep")),
+                        ),
+                    ),
+                requiredProperties = setOf("outer"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(inner, outer, holder)))
+        val param = files
+            .first { it.name == "Holder" }
+            .members
+            .filterIsInstance<TypeSpec>()[0]
+            .primaryConstructor!!
+            .parameters
+            .first { it.name == "outer" }
+        assertEquals(
+            "com.example.model.Outer(child = com.example.model.Inner(content = \"deep\"))",
+            param.defaultValue.toString(),
+        )
+    }
+
+    @Test
+    fun `scalar reference default emits enum constant`() {
+        val statusEnum =
+            EnumModel(
+                name = "Status",
+                description = null,
+                type = EnumBackingType.STRING,
+                values = listOf(EnumModel.Value("active"), EnumModel.Value("closed")),
+            )
+        val schema =
+            SchemaModel(
+                name = "Config",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel("status", TypeRef.Reference("Status"), null, false, "active"),
+                    ),
+                requiredProperties = setOf("status"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(schema), enums = listOf(statusEnum)))
+        val param = files
+            .first { it.name == "Config" }
+            .members
+            .filterIsInstance<TypeSpec>()[0]
+            .primaryConstructor!!
+            .parameters
+            .first { it.name == "status" }
+        assertEquals("com.example.model.Status.ACTIVE", param.defaultValue.toString())
+    }
+
+    /** Convenience: build a single-schema spec, generate, and return the named constructor parameter. */
+    private fun defaultParamOf(
+        schemas: List<SchemaModel>,
+        enums: List<EnumModel> = emptyList(),
+        className: String,
+        paramName: String,
+    ): ParameterSpec {
+        val files = generate(spec(schemas = schemas, enums = enums))
+        return files
+            .first { it.name == className }
+            .members
+            .filterIsInstance<TypeSpec>()[0]
+            .primaryConstructor!!
+            .parameters
+            .first { it.name == paramName }
+    }
+
+    private fun refHolder(refSchemaName: String, default: Any?) = SchemaModel(
+        name = "Holder",
+        description = null,
+        properties = listOf(PropertyModel("value", TypeRef.Reference(refSchemaName), null, false, default)),
+        requiredProperties = setOf("value"),
+        allOf = null,
+        oneOf = null,
+        anyOf = null,
+        discriminator = null,
+    )
+
+    @Test
+    fun `empty object default constructs referenced class with no arguments`() {
+        val target =
+            SchemaModel(
+                name = "TaskConfig",
+                description = null,
+                properties = listOf(PropertyModel("taskName", TypeRef.Primitive(PrimitiveType.STRING), null, true)),
+                requiredProperties = emptySet(),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val param = defaultParamOf(
+            schemas = listOf(target, refHolder("TaskConfig", emptyMap<String, Any?>())),
+            className = "Holder",
+            paramName = "value",
+        )
+        assertEquals("com.example.model.TaskConfig()", param.defaultValue.toString())
+    }
+
+    @Test
+    fun `object default with enum reference property emits nested enum constant`() {
+        val statusEnum =
+            EnumModel(
+                name = "Status",
+                description = null,
+                type = EnumBackingType.STRING,
+                values = listOf(EnumModel.Value("active"), EnumModel.Value("closed")),
+            )
+        val target =
+            SchemaModel(
+                name = "TaskConfig",
+                description = null,
+                properties = listOf(PropertyModel("status", TypeRef.Reference("Status"), null, false)),
+                requiredProperties = setOf("status"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val param = defaultParamOf(
+            schemas = listOf(target, refHolder("TaskConfig", mapOf("status" to "closed"))),
+            enums = listOf(statusEnum),
+            className = "Holder",
+            paramName = "value",
+        )
+        assertEquals(
+            "com.example.model.TaskConfig(status = com.example.model.Status.CLOSED)",
+            param.defaultValue.toString(),
+        )
+    }
+
+    @Test
+    fun `object default with date-time property emits Instant parse call`() {
+        val target =
+            SchemaModel(
+                name = "TaskConfig",
+                description = null,
+                properties = listOf(
+                    PropertyModel("createdAt", TypeRef.Primitive(PrimitiveType.DATE_TIME), null, false),
+                ),
+                requiredProperties = setOf("createdAt"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val param = defaultParamOf(
+            schemas = listOf(target, refHolder("TaskConfig", mapOf("createdAt" to "2024-01-01T00:00:00Z"))),
+            className = "Holder",
+            paramName = "value",
+        )
+        assertTrue(
+            param.defaultValue.toString().contains("Instant.parse(\"2024-01-01T00:00:00Z\")"),
+            "Expected Instant.parse inside constructor, got: ${param.defaultValue}",
+        )
+    }
+
+    @Test
+    fun `object default with float property emits float literal`() {
+        val target =
+            SchemaModel(
+                name = "TaskConfig",
+                description = null,
+                properties = listOf(PropertyModel("ratio", TypeRef.Primitive(PrimitiveType.FLOAT), null, false)),
+                requiredProperties = setOf("ratio"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val param = defaultParamOf(
+            schemas = listOf(target, refHolder("TaskConfig", mapOf("ratio" to 1.5))),
+            className = "Holder",
+            paramName = "value",
+        )
+        assertEquals("com.example.model.TaskConfig(ratio = 1.5f)", param.defaultValue.toString())
+    }
+
+    @Test
+    fun `object default referencing an unknown schema throws IllegalArgumentException`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            generate(spec(schemas = listOf(refHolder("DoesNotExist", mapOf("x" to 1)))))
+        }
+        assertTrue(
+            ex.message.orEmpty().contains("unknown schema"),
+            "Expected unknown-schema message, got: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun `reference default with invalid value type fails`() {
+        val target =
+            SchemaModel(
+                name = "TaskConfig",
+                description = null,
+                properties = listOf(PropertyModel("x", TypeRef.Primitive(PrimitiveType.INT), null, true)),
+                requiredProperties = emptySet(),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        // A bare Int is neither an enum constant (String) nor an object (Map) default.
+        assertFailsWith<IllegalStateException> {
+            generate(spec(schemas = listOf(target, refHolder("TaskConfig", 42))))
+        }
+    }
+
+    @Test
+    fun `array of object references default emits listOf of constructed classes`() {
+        val item =
+            SchemaModel(
+                name = "Item",
+                description = null,
+                properties = listOf(PropertyModel("label", TypeRef.Primitive(PrimitiveType.STRING), null, false)),
+                requiredProperties = setOf("label"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val holder =
+            SchemaModel(
+                name = "Holder",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "items",
+                            TypeRef.Array(TypeRef.Reference("Item")),
+                            null,
+                            false,
+                            listOf(mapOf("label" to "a"), mapOf("label" to "b")),
+                        ),
+                    ),
+                requiredProperties = setOf("items"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val param = defaultParamOf(schemas = listOf(item, holder), className = "Holder", paramName = "items")
+        assertEquals(
+            "listOf(com.example.model.Item(label = \"a\"), com.example.model.Item(label = \"b\"))",
+            param.defaultValue.toString(),
+        )
+    }
+
+    @Test
+    fun `unique array of enum references default emits setOf of enum constants`() {
+        val statusEnum =
+            EnumModel(
+                name = "Status",
+                description = null,
+                type = EnumBackingType.STRING,
+                values = listOf(EnumModel.Value("active"), EnumModel.Value("closed")),
+            )
+        val schema =
+            SchemaModel(
+                name = "Config",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel(
+                            "statuses",
+                            TypeRef.Array(TypeRef.Reference("Status"), unique = true),
+                            null,
+                            false,
+                            listOf("active", "closed"),
+                        ),
+                    ),
+                requiredProperties = setOf("statuses"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val param = defaultParamOf(
+            schemas = listOf(schema),
+            enums = listOf(statusEnum),
+            className = "Config",
+            paramName = "statuses",
+        )
+        assertEquals(
+            "setOf(com.example.model.Status.ACTIVE, com.example.model.Status.CLOSED)",
+            param.defaultValue.toString(),
+        )
     }
 
     @Test

--- a/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserDefaultsTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/parser/SpecParserDefaultsTest.kt
@@ -61,4 +61,53 @@ class SpecParserDefaultsTest : SpecParserTestBase() {
         assertFalse(secret.nullable, "property with a byte-array default must not be nullable")
         assertNotNull(secret.defaultValue, "byte-array default value must be retained")
     }
+
+    @Test
+    fun `unique array default is normalized to a plain List and property is non-nullable`() {
+        val uniqueTags = props.getValue("uniqueTags")
+        assertFalse(uniqueTags.nullable)
+        assertEquals(listOf("X", "Y"), uniqueTags.defaultValue)
+    }
+
+    @Test
+    fun `object reference default is normalized to a plain Map and property is non-nullable`() {
+        val config = props.getValue("config")
+        assertFalse(config.nullable, "property with an object default must not be nullable")
+        assertEquals(
+            mapOf("taskName" to null, "parameters" to emptyList<Any?>(), "isActive" to false),
+            config.defaultValue,
+        )
+    }
+
+    @Test
+    fun `map-type default is not honored and property stays nullable`() {
+        // A free-form map default is not honored: the property stays nullable, so the model
+        // layer emits `= null` regardless of the retained raw default value.
+        val rawMap = props.getValue("rawMap")
+        assertTrue(rawMap.nullable, "free-form map default must not be honored")
+    }
+
+    @Test
+    fun `array of object defaults is normalized to a List of Maps`() {
+        val configs = props.getValue("configs")
+        assertFalse(configs.nullable)
+        assertEquals(
+            listOf(
+                mapOf("taskName" to "first", "isActive" to true),
+                mapOf("taskName" to "second"),
+            ),
+            configs.defaultValue,
+        )
+    }
+
+    @Test
+    fun `object default preserves nested scalar values and types`() {
+        val config = props.getValue("config")
+
+        @Suppress("UNCHECKED_CAST")
+        val map = config.defaultValue as Map<String, Any?>
+        assertEquals(false, map["isActive"])
+        assertTrue(map.containsKey("taskName"))
+        assertEquals(null, map["taskName"])
+    }
 }

--- a/core/src/test/resources/fixtures/property-defaults-spec.json
+++ b/core/src/test/resources/fixtures/property-defaults-spec.json
@@ -33,7 +33,46 @@
             "type": "string",
             "format": "byte",
             "default": "AAEC"
+          },
+          "uniqueTags": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "string" },
+            "default": ["X", "Y"]
+          },
+          "config": {
+            "allOf": [{ "$ref": "#/components/schemas/TaskConfig" }],
+            "default": {
+              "taskName": null,
+              "parameters": [],
+              "isActive": false
+            }
+          },
+          "rawMap": {
+            "type": "object",
+            "additionalProperties": { "type": "string" },
+            "default": { "k": "v" }
+          },
+          "configs": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TaskConfig" },
+            "default": [
+              { "taskName": "first", "isActive": true },
+              { "taskName": "second" }
+            ]
           }
+        }
+      },
+      "TaskConfig": {
+        "type": "object",
+        "properties": {
+          "taskName": { "type": "string", "nullable": true, "default": null },
+          "parameters": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": []
+          },
+          "isActive": { "type": "boolean", "default": false }
         }
       }
     }


### PR DESCRIPTION
## Problem

Generated client code failed to compile when a property declared a default referencing a data-class schema (`$ref`). The default was emitted via the enum-constant path, producing a syntax error:

```kotlin
val config: TaskConfig = TaskConfig.   // syntax error
```

## Fix

- The Reference default branch now distinguishes enum constants (scalar default) from object defaults (Map). Object defaults construct the referenced class with named arguments, recursing per property:
  ```kotlin
  val config: TaskConfig = TaskConfig(taskName = null, parameters = emptyList(), isActive = false)
  ```
- `SpecParser.normalizeDefault` unwraps Jackson `ObjectNode` defaults into plain Kotlin `Map`s and pattern-matches all `JsonNode` subtypes (numbers via `NumericNode.numberValue()`).

Named arguments are required (not bare `%T()`) because the default object may override only some properties, and the referenced class may have required properties.

## Tests

Coverage added to `ModelGeneratorTest` and `SpecParserDefaultsTest`: object defaults, empty objects, nested objects, enum references inside objects, scalar overrides, unknown-key skipping, array-of-objects, and invalid-default error paths.

## Verified end-to-end

Published locally and regenerated `cem-mobile-app-justworks`: `TaskTemplateInvocation.config` now compiles; backend builds clean.

> Builds on #96 (unique-array Set defaults), already merged to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)