### PR TITLE
fix(core): use backtick-escaped constant reference for enum default values

### DIFF
--- a/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
+++ b/core/src/main/kotlin/com/avsystem/justworks/core/gen/model/ModelGenerator.kt
@@ -564,7 +564,7 @@ internal object ModelGenerator {
                 }
 
                 is String -> {
-                    CodeBlock.of("%T.%L", className, value.toEnumConstantName())
+                    CodeBlock.of("%T.%N", className, value.toEnumConstantName())
                 }
 
                 else -> {

--- a/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorTest.kt
+++ b/core/src/test/kotlin/com/avsystem/justworks/core/gen/ModelGeneratorTest.kt
@@ -641,6 +641,40 @@ class ModelGeneratorTest {
     }
 
     @Test
+    fun `enum default with numeric string value uses backtick-escaped constant reference`() {
+        val floorEnum =
+            EnumModel(
+                name = "Floor",
+                description = null,
+                type = EnumBackingType.STRING,
+                values = listOf(EnumModel.Value("1"), EnumModel.Value("2"), EnumModel.Value("3")),
+            )
+        val schema =
+            SchemaModel(
+                name = "Request",
+                description = null,
+                properties =
+                    listOf(
+                        PropertyModel("floor", TypeRef.Reference("Floor"), null, false, "1"),
+                    ),
+                requiredProperties = setOf("floor"),
+                allOf = null,
+                oneOf = null,
+                anyOf = null,
+                discriminator = null,
+            )
+        val files = generate(spec(schemas = listOf(schema), enums = listOf(floorEnum)))
+        val typeSpec = files.first { it.name == "Request" }.members.filterIsInstance<TypeSpec>()[0]
+        val constructor = assertNotNull(typeSpec.primaryConstructor)
+        val param = constructor.parameters.first { it.name == "floor" }
+        val defaultStr = param.defaultValue.toString()
+        assertTrue(
+            defaultStr.contains("`1`"),
+            "Expected backtick-escaped `1`, got: $defaultStr",
+        )
+    }
+
+    @Test
     fun `array property with default emits listOf with element literals`() {
         val schema =
             SchemaModel(


### PR DESCRIPTION
When an enum value produces a constant name that is not a valid Kotlin
identifier (e.g. "1" → `1`), the generated default value was emitted
without backticks, causing a compilation error:

    data class Request(
        val floor: Floor = Floor.1  // invalid
    )

Using `%N` instead of `%L` in KotlinPoet's CodeBlock lets the library
apply backtick escaping automatically:

    data class Request(
        val floor: Floor = Floor.`1`  // correct
    )

Adds a regression test covering a numeric-string enum default.