### PR TITLE
Add codeql yml file

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,4 +74,3 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: /language:java-kotlin
-          upload: never

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,77 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '27 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          # Only master writes the cache; PRs read it. Keeps the cache from being
+          # polluted by branch builds while still avoiding the wrapper download.
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
+
+      # The distribution download from services.gradle.org is the flaky part.
+      # Do it here, outside the traced build, and retry instead of failing the run.
+      - name: Warm up Gradle
+        run: |
+          for attempt in 1 2 3; do
+            if ./gradlew --version; then exit 0; fi
+            delay=$((attempt * 15))
+            echo "::warning::Gradle distribution download failed (attempt ${attempt}/3), retrying in ${delay}s"
+            sleep "${delay}"
+          done
+          echo "::error::Could not provision Gradle after 3 attempts"
+          exit 1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          build-mode: manual
+          # Drop this line to fall back to the default suite if the extra
+          # lower-precision queries turn out to be too noisy.
+          queries: security-extended
+
+      # CodeQL builds its database by tracing the compiler, so compilation must
+      # actually happen: gradle.properties enables the build and configuration
+      # caches, both of which would let Gradle skip the work and leave CodeQL
+      # with an empty database.
+      - name: Build
+        run: ./gradlew classes --no-daemon --no-build-cache --no-configuration-cache
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:java-kotlin
+          upload: never

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             if ./gradlew --version; then exit 0; fi
+            if [ "${attempt}" -eq 3 ]; then break; fi
             delay=$((attempt * 15))
             echo "::warning::Gradle distribution download failed (attempt ${attempt}/3), retrying in ${delay}s"
             sleep "${delay}"


### PR DESCRIPTION
## Why

This repo had no security code scanning. It had **GitHub Code Quality**, which runs as a *dynamic* workflow—no Gradle caching and **not re-runnable**.

On #106, the Gradle wrapper download timed out, and with the `code_quality` ruleset rule gating merges, the only escape was:

```bash
git commit --allow-empty
```

That blocking issue has already been fixed by a settings change (described below). This PR adds the missing security scanning as a real workflow file so it's cached and re-runnable.

## What changed

Adds `.github/workflows/codeql.yml` — CodeQL advanced setup for `java-kotlin`.

Triggers:
- Push to `master`
- Pull requests targeting `master`
- Weekly scheduled run
- Manual dispatch

Key configuration:

- `build-mode: manual` — Kotlin can't be analyzed buildless.
- **`--no-build-cache --no-configuration-cache` are load-bearing.** CodeQL builds its database by tracing the compiler. Since `gradle.properties` enables both caches, a cached `compileKotlin` would produce an empty database—a green check that analyzed nothing.
- `setup-gradle@v4` caches the Gradle distribution and adds a 3× retry for cold starts (addressing the #106 failure).
- `queries: security-extended` — free on public repositories, with roughly 30–60% longer analysis time.

Verified on this PR:

- ✅ Green in ~2 minutes.
- ✅ `Code scanning results / CodeQL` reports no new alerts.

## Settings changed outside this diff

- **Removed the `code_quality` ruleset rule** — this was what allowed flaky runs to block merges. Quality findings no longer gate pull requests; GitHub only provides that gate through the non-rerunnable workflow.
- **Disabled Code Quality analysis** to avoid compiling the project twice. This is reversible—re-enabling it restores quality findings as informational results.

## Follow-ups

- [ ] Fold `code-quality` into the workflow once `analysis-kinds` is no longer `[Internal]`.
- [ ] Add `package-ecosystem: github-actions` to `dependabot.yml` (currently Gradle only).

---

Unblocks #106.