### PR TITLE
Generate and publish KDoc via Dokka + GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: Docs
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Generate API docs
+        run: ./gradlew :dokkaGenerate
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/dokka
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Gradle plugin that generates type-safe Kotlin [Ktor](https://ktor.io/) client code from OpenAPI 3.0 specifications.
 
+API documentation: https://avsystem.github.io/justworks/
+
 ## Installation
 
 Add the plugin to your `build.gradle.kts`:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0" apply false
     id("org.jetbrains.kotlinx.kover") version "0.9.9" apply false
     id("com.vanniktech.maven.publish") version "0.37.0" apply false
+    id("org.jetbrains.dokka") version "2.2.0"
 }
 
 allprojects {
@@ -61,5 +62,19 @@ subprojects {
                 }
             }
         }
+    }
+}
+
+dependencies {
+    dokka(project(":core"))
+    dokka(project(":plugin"))
+}
+
+dokka {
+    moduleName.set("justworks")
+
+    dokkaPublications.html {
+        outputDirectory.set(layout.buildDirectory.dir("dokka"))
+        includes.from("README.md")
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -4,10 +4,23 @@ plugins {
     kotlin("jvm")
     id("org.jetbrains.kotlinx.kover")
     id("com.vanniktech.maven.publish")
+    id("org.jetbrains.dokka") version "2.2.0"
 }
 
 kotlin {
     jvmToolchain(21)
+}
+
+dokka {
+    moduleName.set("justworks-core")
+
+    dokkaSourceSets.main {
+        sourceLink {
+            localDirectory.set(file("src/main/kotlin"))
+            remoteUrl("https://github.com/AVSystem/justworks/tree/master/core/src/main/kotlin")
+            remoteLineSuffix.set("#L")
+        }
+    }
 }
 
 // todo: remove when https://github.com/JLLeitschuh/ktlint-gradle/issues/912 resolved

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -6,10 +6,23 @@ plugins {
     `java-gradle-plugin`
     id("com.vanniktech.maven.publish")
     id("org.jetbrains.kotlinx.kover")
+    id("org.jetbrains.dokka") version "2.2.0"
 }
 
 kotlin {
     jvmToolchain(21)
+}
+
+dokka {
+    moduleName.set("justworks-plugin")
+
+    dokkaSourceSets.main {
+        sourceLink {
+            localDirectory.set(file("src/main/kotlin"))
+            remoteUrl("https://github.com/AVSystem/justworks/tree/master/plugin/src/main/kotlin")
+            remoteLineSuffix.set("#L")
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- Adds the Dokka Gradle plugin (v2.2.0) to `core` and `plugin`, aggregated at the root so `./gradlew :dokkaGenerate` produces a single HTML site under `build/dokka` covering both modules, with source links back to GitHub.
- Adds `.github/workflows/docs.yml`, which builds the docs and deploys them to GitHub Pages on every push to `master` (also runnable manually via `workflow_dispatch`).
- `core`'s Maven Central javadoc jar is now auto-derived from Dokka instead of being empty (`plugin` keeps `JavadocJar.Empty()`, which is standard for Gradle plugins).
- Adds an API docs link to the README.

## Post-merge setup (one-time, needs repo admin)
GitHub Pages must be enabled before the workflow can actually publish anything:
1. Go to **Settings → Pages** on this repo.
2. Under **Build and deployment → Source**, select **GitHub Actions**.
3. Re-run the `Docs` workflow (or push to `master`) if it already ran and failed on the deploy step before Pages was enabled.

Once enabled, docs will be live at `https://avsystem.github.io/justworks/` and stay up to date automatically on every merge to `master`.

## Test plan
- [x] `./gradlew :dokkaGenerate` succeeds locally, produces `build/dokka/index.html` aggregating both modules
- [x] `./gradlew ktlintCheck` passes
- [ ] `docs.yml` workflow succeeds on GitHub Actions (needs Pages enabled first, see above)